### PR TITLE
Add Renovate config to auto-update base image digests

### DIFF
--- a/cuda/12.8/app.conf
+++ b/cuda/12.8/app.conf
@@ -24,8 +24,9 @@ PYTHON_VERSION=3.12
 # Base Image
 # -----------------------------------------------------------------------------
 # Use sclorg Python image on CentOS Stream 9 (UBI 9 lacks CUDA dependencies)
-# For reproducible builds, override with a pinned digest
-BASE_IMAGE=quay.io/sclorg/python-312-c9s:c9s
+# Digest is pinned for reproducible builds and auto-updated by Renovate
+# Source: https://quay.io/repository/sclorg/python-312-c9s
+BASE_IMAGE=quay.io/sclorg/python-312-c9s:c9s@sha256:9a5887b50d29dd1a307ab6e7b25885203c977a856dca75c9c64d135f571f8b54
 
 # -----------------------------------------------------------------------------
 # CUDA Versions

--- a/cuda/12.9/app.conf
+++ b/cuda/12.9/app.conf
@@ -24,8 +24,9 @@ PYTHON_VERSION=3.12
 # Base Image
 # -----------------------------------------------------------------------------
 # Use sclorg Python image on CentOS Stream 9 (UBI 9 lacks CUDA dependencies)
-# For reproducible builds, override with a pinned digest
-BASE_IMAGE=quay.io/sclorg/python-312-c9s:c9s
+# Digest is pinned for reproducible builds and auto-updated by Renovate
+# Source: https://quay.io/repository/sclorg/python-312-c9s
+BASE_IMAGE=quay.io/sclorg/python-312-c9s:c9s@sha256:9a5887b50d29dd1a307ab6e7b25885203c977a856dca75c9c64d135f571f8b54
 
 # -----------------------------------------------------------------------------
 # CUDA Versions

--- a/cuda/13.0/app.conf
+++ b/cuda/13.0/app.conf
@@ -24,8 +24,9 @@ PYTHON_VERSION=3.12
 # Base Image
 # -----------------------------------------------------------------------------
 # Use sclorg Python image on CentOS Stream 9 (UBI 9 lacks CUDA dependencies)
-# For reproducible builds, override with a pinned digest
-BASE_IMAGE=quay.io/sclorg/python-312-c9s:c9s
+# Digest is pinned for reproducible builds and auto-updated by Renovate
+# Source: https://quay.io/repository/sclorg/python-312-c9s
+BASE_IMAGE=quay.io/sclorg/python-312-c9s:c9s@sha256:9a5887b50d29dd1a307ab6e7b25885203c977a856dca75c9c64d135f571f8b54
 
 # -----------------------------------------------------------------------------
 # CUDA Versions

--- a/cuda/13.1/app.conf
+++ b/cuda/13.1/app.conf
@@ -24,8 +24,9 @@ PYTHON_VERSION=3.12
 # Base Image
 # -----------------------------------------------------------------------------
 # Use sclorg Python image on CentOS Stream 9 (UBI 9 lacks CUDA dependencies)
-# For reproducible builds, override with a pinned digest
-BASE_IMAGE=quay.io/sclorg/python-312-c9s:c9s
+# Digest is pinned for reproducible builds and auto-updated by Renovate
+# Source: https://quay.io/repository/sclorg/python-312-c9s
+BASE_IMAGE=quay.io/sclorg/python-312-c9s:c9s@sha256:9a5887b50d29dd1a307ab6e7b25885203c977a856dca75c9c64d135f571f8b54
 
 # -----------------------------------------------------------------------------
 # CUDA Versions

--- a/python/3.12/app.conf
+++ b/python/3.12/app.conf
@@ -20,9 +20,9 @@ IMAGE_TAG=py312
 # -----------------------------------------------------------------------------
 # Use full UBI Python image for broader compatibility
 # Using version stream tag '1' for stable updates within UBI 9.x
-# For fully reproducible builds, override with a pinned digest:
-#   podman build --build-arg BASE_IMAGE=registry.access.redhat.com/ubi9/python-312@sha256:...
-BASE_IMAGE=registry.access.redhat.com/ubi9/python-312:1
+# Digest is pinned for reproducible builds and auto-updated by Renovate
+# Source: https://catalog.redhat.com/software/containers/ubi9/python-312
+BASE_IMAGE=registry.access.redhat.com/ubi9/python-312:1@sha256:7a5af0831851a34daf12fd706aed9a5b4f54ef1ae2826a932403b85a9e290c14
 
 # -----------------------------------------------------------------------------
 # PyPI Indexes

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    "Renovate config for base-containers, works with Konflux MintMaker",
+    "https://konflux.pages.redhat.com/docs/users/mintmaker/user.html"
+  ],
+  "extends": [
+    "config:recommended",
+    "docker:pinDigests"
+  ],
+  "labels": ["dependencies"],
+  "branchPrefix": "konflux/mintmaker/",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update BASE_IMAGE in app.conf files",
+      "fileMatch": [
+        "(^|/)python/[^/]+/app\\.conf$",
+        "(^|/)cuda/[^/]+/app\\.conf$"
+      ],
+      "matchStrings": [
+        "BASE_IMAGE=(?<depName>[^:]+):(?<currentValue>[^@\\s]+)(@(?<currentDigest>sha256:[a-f0-9]+))?"
+      ],
+      "autoReplaceStringTemplate": "BASE_IMAGE={{depName}}:{{newValue}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Base image updates for python/*/app.conf",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["registry.access.redhat.com/ubi9/python-312"],
+      "groupName": "ubi-python-image"
+    },
+    {
+      "description": "Base image updates for cuda/*/app.conf",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["quay.io/sclorg/python-312-c9s"],
+      "groupName": "sclorg-python-image"
+    }
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Configure Renovate to track BASE_IMAGE in app.conf files and automatically open PRs when upstream images are updated. MintMaker will handle this automatically since Konflux pipelines (.tekton/) are already set up. MintMaker's defaults already include the custom.regex manager we're using.

## Description
- Add renovate.json with regex manager for app.conf files
- Pin BASE_IMAGE to current digest in python/3.12 and cuda/* configs
- Create separate PRs for UBI and sclorg image updates
- Use MintMaker branch prefix for Konflux compatibility

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned Docker base image digests across CUDA and Python build configurations to ensure reproducible builds.
  * Added automated update configuration to keep those pinned base images current via scheduled tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->