### PR TITLE
fix(tekton): add version-specific path filters to Konflux pipelines

### DIFF
--- a/.tekton/odh-midstream-cuda-base-main-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-main-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && ("cuda/12.8/**".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: odh-base-containers

--- a/.tekton/odh-midstream-cuda-base-main-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-main-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && ("cuda/12.8/**".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: odh-base-containers

--- a/.tekton/odh-midstream-python-base-main-pull-request.yaml
+++ b/.tekton/odh-midstream-python-base-main-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && ("python/3.12/**".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: odh-base-containers

--- a/.tekton/odh-midstream-python-base-main-push.yaml
+++ b/.tekton/odh-midstream-python-base-main-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && ("python/3.12/**".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: odh-base-containers


### PR DESCRIPTION
Fixes #19 

Trigger CUDA 12.8 and Python 3.12 pipelines only when their respective version directories change.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD trigger behavior tightened: pipelines for CUDA 12.8 now run only when CUDA 12.8-related files change, and pipelines for Python 3.12 now run only when Python 3.12-related files change, for both pull-request and push events—reducing unnecessary runs and focusing execution on relevant code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->