### PR TITLE
Optimize CI to test only container images affected by changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     outputs:
       any-cuda: ${{ steps.filter.outputs['any-cuda'] }}
       any-python: ${{ steps.filter.outputs['any-python'] }}
+      cuda-versions: ${{ steps.cuda-versions.outputs.versions }}
+      python-versions: ${{ steps.python-versions.outputs.versions }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -26,21 +28,78 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
+          list-files: json
           filters: |
             any-cuda:
-              - 'cuda/**'
-              - 'Containerfile.cuda.template'
+              - 'cuda/**/Containerfile'
+              - 'cuda/**/app.conf'
+              - 'scripts/fix-permissions'
               - 'scripts/build.sh'
+              - 'requirements-build.txt'
+              - 'tests/test_common.py'
+              - 'tests/conftest.py'
               - 'tests/test_cuda_image.py'
-              - 'tests/test_common.py'
-              - 'tests/conftest.py'
             any-python:
-              - 'python/**'
-              - 'Containerfile.python.template'
+              - 'python/**/Containerfile'
+              - 'python/**/app.conf'
+              - 'scripts/fix-permissions'
               - 'scripts/build.sh'
-              - 'tests/test_python_image.py'
+              - 'requirements-build.txt'
               - 'tests/test_common.py'
               - 'tests/conftest.py'
+              - 'tests/test_python_image.py'  
+
+      - name: Build CUDA version matrix
+        id: cuda-versions
+        if: steps.filter.outputs.any-cuda == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.filter.outputs.any-cuda_files }}
+        run: |
+          # Check if common files changed (affects all versions)
+          if echo "$CHANGED_FILES" | grep -qE 'requirements-build\.txt|scripts/fix-permissions|scripts/build\.sh|tests/'; then
+            echo "Common files changed - including all CUDA versions"
+            # Get all available CUDA versions from directory structure
+            VERSIONS=$(find cuda -maxdepth 1 -type d -name '[0-9]*.[0-9]*' \
+              | sed 's|cuda/||' \
+              | sort -V \
+              | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?",":""), $0} END{print "]"}')
+          else
+            # Extract only specific versions from changed cuda/<version>/{Containerfile,app.conf} paths
+            VERSIONS=$(echo "$CHANGED_FILES" \
+              | tr -d '[]" ' \
+              | tr ',' '\n' \
+              | awk -F/ '$1=="cuda" && $2 ~ /^[0-9]+\.[0-9]+$/ && ($3=="Containerfile" || $3=="app.conf") {print $2}' \
+              | sort -uV \
+              | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?",":""), $0} END{print "]"}')
+          fi
+          
+          echo "versions=${VERSIONS}" >> "$GITHUB_OUTPUT"
+
+      - name: Build Python version matrix
+        id: python-versions
+        if: steps.filter.outputs.any-python == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.filter.outputs.any-python_files }}
+        run: |
+          # Check if common files changed (affects all versions)
+          if echo "$CHANGED_FILES" | grep -qE 'requirements-build\.txt|scripts/fix-permissions|scripts/build\.sh|tests/'; then
+            echo "Common files changed - including all Python versions"
+            # Get all available Python versions from directory structure
+            VERSIONS=$(find python -maxdepth 1 -type d -name '[0-9]*.[0-9]*' \
+              | sed 's|python/||' \
+              | sort -V \
+              | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?",":""), $0} END{print "]"}')
+          else
+            # Extract only specific versions from changed python/<version>/{Containerfile,app.conf} paths
+            VERSIONS=$(echo "$CHANGED_FILES" \
+              | tr -d '[]" ' \
+              | tr ',' '\n' \
+              | awk -F/ '$1=="python" && $2 ~ /^[0-9]+\.[0-9]+$/ && ($3=="Containerfile" || $3=="app.conf") {print $2}' \
+              | sort -uV \
+              | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?",":""), $0} END{print "]"}')
+          fi
+          
+          echo "versions=${VERSIONS}" >> "$GITHUB_OUTPUT"
 
   lint:
     name: Lint (ruff)
@@ -130,12 +189,14 @@ jobs:
     if: |
       always() &&
       needs.changes.outputs['any-python'] == 'true' &&
+      needs.changes.outputs.python-versions != '' &&
+      needs.changes.outputs.python-versions != '[]' &&
       needs.lint.result == 'success' &&
       needs.type-check.result == 'success' &&
       (needs.lint-containerfiles.result == 'success' || needs.lint-containerfiles.result == 'skipped')
     strategy:
       matrix:
-        version: ["3.12"]
+        version: ${{ fromJSON(needs.changes.outputs.python-versions || '[]') }}
       fail-fast: false
     steps:
       - uses: actions/checkout@v6
@@ -175,12 +236,14 @@ jobs:
     if: |
       always() &&
       needs.changes.outputs['any-cuda'] == 'true' &&
+      needs.changes.outputs.cuda-versions != '' &&
+      needs.changes.outputs.cuda-versions != '[]' &&
       needs.lint.result == 'success' &&
       needs.type-check.result == 'success' &&
       (needs.lint-containerfiles.result == 'success' || needs.lint-containerfiles.result == 'skipped')
     strategy:
       matrix:
-        version: ["12.8", "12.9", "13.0", "13.1"]
+        version: ${{ fromJSON(needs.changes.outputs.cuda-versions || '[]') }}
       fail-fast: false
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
- Extract version matrix dynamically from changed paths
- Narrow CI filters to trigger builds and tests only when actual files related to containers change

Changes:
- Changes specific to version-specific file will build only affected versions
- Changes to common file will build and test all available versions
- Guard conditions prevent empty matrix errors

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now exposes CUDA and Python version outputs as JSON arrays for downstream jobs.
  * Adds dynamic generation of CUDA/Python version matrices so builds/tests run only for impacted versions.
  * Lint/type-check/test and image-test jobs consume these outputs and guard against empty version lists.
  * Tightened change filters and adjusted aggregator outputs to better align triggered workflows with actual changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->