### PR TITLE
Amend Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
   ],
   "extends": [
     "config:recommended",
-    "docker:pinDigests"
+    "docker:pinDigests",
+    "workarounds:supportRedHatImageVersion"
   ],
   "labels": ["dependencies"],
   "branchPrefix": "konflux/mintmaker/",
@@ -22,22 +23,21 @@
         "BASE_IMAGE=(?<depName>[^:]+):(?<currentValue>[^@\\s]+)(@(?<currentDigest>sha256:[a-f0-9]+))?"
       ],
       "autoReplaceStringTemplate": "BASE_IMAGE={{depName}}:{{newValue}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "docker"
+      "datasourceTemplate": "docker"
     }
   ],
   "packageRules": [
     {
-      "description": "Base image updates for python/*/app.conf",
+      "description": "Group all base image updates together",
       "matchManagers": ["custom.regex"],
-      "matchDepNames": ["registry.access.redhat.com/ubi9/python-312"],
-      "groupName": "ubi-python-image"
+      "groupName": "base-images",
+      "separateMajorMinor": false
     },
     {
-      "description": "Base image updates for cuda/*/app.conf",
-      "matchManagers": ["custom.regex"],
-      "matchDepNames": ["quay.io/sclorg/python-312-c9s"],
-      "groupName": "sclorg-python-image"
+      "description": "Use Red Hat versioning for UBI images",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["/^registry\\.access\\.redhat\\.com/"],
+      "versioning": "redhat"
     }
   ]
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description


<!--- Describe your changes in detail -->
- closes #48 
- use RedHat workaround for image version and digest parsing
- avoid duplicate PRs for major/minor version updates

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency update configuration to support Red Hat container image versioning across updates.
  * Reorganized base-image grouping to consolidate related base-image updates and enforce consistent grouping behavior.
  * Added a targeted rule to handle registry-hosted Red Hat images using Red Hat-specific versioning so those images are processed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->