### PR TITLE
bump Tekton pipeline timeout to 2 hours

### DIFF
--- a/.tekton/odh-midstream-cuda-base-12-8-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-8-pull-request.yaml
@@ -23,6 +23,8 @@ metadata:
   name: odh-midstream-cuda-base-12-8-on-pull-request
   namespace: open-data-hub-tenant
 spec:
+  timeouts:
+    pipeline: "2h0m0s"
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/.tekton/odh-midstream-cuda-base-12-8-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-8-push.yaml
@@ -22,6 +22,8 @@ metadata:
   name: odh-midstream-cuda-base-12-8-on-push
   namespace: open-data-hub-tenant
 spec:
+  timeouts:
+    pipeline: "2h0m0s"
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/.tekton/odh-midstream-cuda-base-12-9-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-9-pull-request.yaml
@@ -23,6 +23,8 @@ metadata:
   name: odh-midstream-cuda-base-12-9-on-pull-request
   namespace: open-data-hub-tenant
 spec:
+  timeouts:
+    pipeline: "2h0m0s"
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/.tekton/odh-midstream-cuda-base-12-9-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-9-push.yaml
@@ -22,6 +22,8 @@ metadata:
   name: odh-midstream-cuda-base-12-9-on-push
   namespace: open-data-hub-tenant
 spec:
+  timeouts:
+    pipeline: "2h0m0s"
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/.tekton/odh-midstream-cuda-base-13-0-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-0-pull-request.yaml
@@ -23,6 +23,8 @@ metadata:
   name: odh-midstream-cuda-base-13-0-on-pull-request
   namespace: open-data-hub-tenant
 spec:
+  timeouts:
+    pipeline: "2h0m0s"
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/.tekton/odh-midstream-cuda-base-13-0-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-0-push.yaml
@@ -22,6 +22,8 @@ metadata:
   name: odh-midstream-cuda-base-13-0-on-push
   namespace: open-data-hub-tenant
 spec:
+  timeouts:
+    pipeline: "2h0m0s"
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/.tekton/odh-midstream-cuda-base-13-1-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-1-pull-request.yaml
@@ -23,6 +23,8 @@ metadata:
   name: odh-midstream-cuda-base-13-1-on-pull-request
   namespace: open-data-hub-tenant
 spec:
+  timeouts:
+    pipeline: "2h0m0s"
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/.tekton/odh-midstream-cuda-base-13-1-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-1-push.yaml
@@ -22,6 +22,8 @@ metadata:
   name: odh-midstream-cuda-base-13-1-on-push
   namespace: open-data-hub-tenant
 spec:
+  timeouts:
+    pipeline: "2h0m0s"
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/.tekton/odh-midstream-python-base-3-12-pull-request.yaml
+++ b/.tekton/odh-midstream-python-base-3-12-pull-request.yaml
@@ -23,6 +23,8 @@ metadata:
   name: odh-midstream-python-base-3-12-on-pull-request
   namespace: open-data-hub-tenant
 spec:
+  timeouts:
+    pipeline: "2h0m0s"
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/.tekton/odh-midstream-python-base-3-12-push.yaml
+++ b/.tekton/odh-midstream-python-base-3-12-push.yaml
@@ -22,6 +22,8 @@ metadata:
   name: odh-midstream-python-base-3-12-on-push
   namespace: open-data-hub-tenant
 spec:
+  timeouts:
+    pipeline: "2h0m0s"
   params:
   - name: git-url
     value: '{{source_url}}'


### PR DESCRIPTION
closes #56 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added 2-hour execution timeout limits to CI/CD pipeline configurations across CUDA 12.8–13.1 and Python 3.12 build pipelines. This prevents indefinite pipeline runs and improves resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->