### PR TITLE
docs: update RATIONALE.md with multiple CUDA versions info

### DIFF
--- a/docs/RATIONALE.md
+++ b/docs/RATIONALE.md
@@ -40,7 +40,7 @@ Provide **common base images** that ODH repositories can build upon:
 | Base Image | Use Case |
 |------------|----------|
 | `Containerfile.python` | CPU workloads, web services |
-| `Containerfile.cuda` | GPU workloads, model training |
+| `Containerfile.cuda` | GPU workloads, model training (multiple CUDA versions: 12.8, 12.9, 13.0, 13.1) |
 
 ### Benefits
 
@@ -73,6 +73,18 @@ FROM quay.io/opendatahub/odh-midstream-cuda-base:12.8-py312
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 ```
+
+## Why Multiple CUDA Versions?
+
+The repository maintains multiple CUDA versions (currently 12.8, 12.9, 13.0, and 13.1) rather than a single version. Supporting multiple CUDA versions enables midstream projects within the Open Data Hub organization to adopt newer CUDA releases more easily during midstream cycles. Introducing newer CUDA versions in midstream first also prepares the team for a smoother transition when the same versions are later promoted to downstream products.
+
+This approach lets consumers pick the CUDA version that matches their needs:
+
+| Scenario | Recommended Version |
+|----------|-------------------|
+| Production stability | Older, well-tested version (e.g. 12.8) |
+| New GPU features | Latest available version (e.g. 13.1) |
+| Gradual migration | Test with newer version before switching |
 
 ## Design Decisions
 


### PR DESCRIPTION
Add rationale for maintaining multiple CUDA versions (12.8, 12.9, 13.0, 13.1) to help midstream projects adopt newer releases and prepare for smoother downstream promotion.

Closes #57



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Base Image table to display supported CUDA versions
  * Added new guidance section on selecting appropriate CUDA versions for different scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->