### PR TITLE
ci: add additional disk cleanup for CUDA builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,29 @@ jobs:
           docker-images: true
           swap-storage: true
 
+      # Additional cleanup (complements jlumbroso action)
+      # Referenced from: https://github.com/opendatahub-io/notebooks/.github/actions/free-up-disk-space
+      - name: Additional disk cleanup
+        run: |
+          # Run cleanup in parallel for speed
+          sudo rm -rf /usr/local/.ghcup &
+          sudo rm -rf /usr/local/share/boost &
+          sudo rm -rf /usr/local/lib/node_modules &
+          sudo rm -rf /opt/hostedtoolcache/CodeQL &
+          sudo rm -rf /opt/hostedtoolcache/go &
+          sudo rm -rf /opt/hostedtoolcache/Ruby &
+          sudo rm -rf /opt/hostedtoolcache/PyPy &
+          wait
+          
+          # Show available space
+          echo "=== Available disk space ==="
+          df -h /
+          AVAILABLE=$(df -BG / | tail -1 | awk '{print $4}' | tr -d 'G')
+          echo "Available: ${AVAILABLE}GB"
+          if [ "$AVAILABLE" -lt 30 ]; then
+            echo "::warning::Less than 30GB available for CUDA build"
+          fi
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Add complementary disk cleanup step after jlumbroso/free-disk-space action to free additional ~5-6GB for CUDA 12.9+ image builds.

Components removed (in parallel for speed):
- /usr/local/.ghcup (Haskell toolchain installer)
- /usr/local/share/boost (Boost C++ libraries)
- /usr/local/lib/node_modules (Global Node.js modules)
- /opt/hostedtoolcache/CodeQL (GitHub code analyzer)
- /opt/hostedtoolcache/go (Go toolchain)
- /opt/hostedtoolcache/Ruby (Ruby)
- /opt/hostedtoolcache/PyPy (PyPy - not used, repo uses CPython)

Pattern referenced from:
https://github.com/opendatahub-io/notebooks/.github/actions/free-up-disk-space

Fixes disk space exhaustion during CUDA 12.9 builds on GitHub Actions.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This pull request contains only internal infrastructure changes to the continuous integration workflow with no impact to end-users or the application itself. Release notes are not applicable for this change.

**Chores**
* Updated CI workflow infrastructure for improved build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->