### PR TITLE
docs: remove outdated CI manual update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,6 @@ Use the generation script to create a new version from the template:
 # Include PYTHON_VERSION and PYTHON_VERSION_NODOT
 ```
 
-After adding a new version, also update `.github/workflows/ci.yml`:
-- Add the version to the `matrix.version` array in the corresponding test job
-- Add a version-specific path filter if desired (e.g., `cuda-13-2`)
-
 ## Build Arguments
 
 Build arguments are defined in `<type>/<version>/app.conf` files. The build script passes these directly via `--build-arg-file`.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -159,6 +159,9 @@ The `ci-status` job always runs and fails if any required job fails or is cancel
 Conditional jobs (like `lint-containerfiles` and `test-cuda-image`) may be skipped
 when changes do not apply.
 
+Version matrices are built dynamically from the directory structure (`cuda/*/`, `python/*/`).
+No manual CI updates are needed when adding new versions.
+
 ### Before Submitting a PR
 
 Ensure your changes pass locally:


### PR DESCRIPTION
The CI workflow now builds version matrices dynamically from the directory structure. Remove instructions in README.md that incorrectly asked users to manually update ci.yml when adding new versions.

Add clarification to DEVELOPMENT.md about the dynamic behavior.

Closes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CI workflow documentation explaining that version matrices are automatically built from directory structure, eliminating the need for manual updates when adding new versions.
  * Simplified setup instructions by removing outdated workflow configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->