### PR TITLE
test: extend CUDA test suite for PyTorch packages and CUDA_HOME

### DIFF
--- a/tests/test_cuda_image.py
+++ b/tests/test_cuda_image.py
@@ -41,6 +41,15 @@ def test_cuda_in_path(cuda_container):
     assert "/usr/local/cuda/bin" in cuda_container.get_env("PATH")
 
 
+def test_cuda_home(cuda_container):
+    """Verify CUDA_HOME points to the CUDA toolkit directory.
+
+    PyTorch source builds (torch.utils.cpp_extension) and Triton JIT kernel
+    compilation rely on CUDA_HOME to locate the toolkit.
+    """
+    assert cuda_container.get_env("CUDA_HOME") == "/usr/local/cuda"
+
+
 # --- CUDA Toolkit Tests ---
 
 
@@ -75,6 +84,41 @@ def test_libcudnn_present(cuda_container):
     """Verify cuDNN library is present."""
     result = cuda_container.run("ldconfig -p | grep libcudnn")
     assert result.returncode == 0
+
+
+# --- PyTorch CUDA Library Tests ---
+
+
+def test_libcupti_present(cuda_container):
+    """Verify CUPTI (CUDA Profiling Tools Interface) library is present.
+
+    Required by the PyTorch profiler for GPU profiling.
+    Installed via cuda-cupti package.
+    """
+    result = cuda_container.run("ldconfig -p | grep libcupti")
+    assert result.returncode == 0, "libcupti.so not found - cuda-cupti package may be missing"
+
+
+def test_libcusparselt_present(cuda_container):
+    """Verify cuSPARSELt (structured sparsity) library is present.
+
+    Used by PyTorch sparse operations for structured sparsity support.
+    Installed via libcusparselt0 package.
+    """
+    result = cuda_container.run("ldconfig -p | grep libcusparseLt")
+    assert result.returncode == 0, (
+        "libcusparseLt.so not found - libcusparselt0 package may be missing"
+    )
+
+
+def test_libcudss_present(cuda_container):
+    """Verify cuDSS (direct sparse solver) library is present.
+
+    Used by scientific and ML solvers for sparse direct solving.
+    Installed via libcudss0-cuda package.
+    """
+    result = cuda_container.run("ldconfig -p | grep libcudss")
+    assert result.returncode == 0, "libcudss.so not found - libcudss0-cuda package may be missing"
 
 
 # --- CUDA Label Tests ---


### PR DESCRIPTION
Add tests to validate the packages from #70 and env var from #69:

- CUDA_HOME env var equals /usr/local/cuda
- libcupti.so present (cuda-cupti package)
- libcusparseLt.so present (libcusparselt0 package)
- libcudss.so present (libcudss0-cuda package)

Closes #74

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation tests for CUDA environment: verifies CUDA_HOME location and expands library checks to include libcupti, libcusparseLt and libcudss, with clear guidance if libraries are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->