### PR TITLE
test: improve test suite consistency and deduplicate constants

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,5 @@
 """ODH Base Container Image Tests."""
+
+# Common paths used across tests
+APP_ROOT = "/opt/app-root"
+WORKDIR = f"{APP_ROOT}/src"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,10 +16,6 @@ import subprocess
 
 import pytest
 
-# Common paths used across tests
-APP_ROOT = "/opt/app-root"
-WORKDIR = f"{APP_ROOT}/src"
-
 
 class ContainerRunner:
     """Efficient container runner using session-scoped container with exec.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -6,9 +6,7 @@ across all ODH base container images.
 
 import pytest
 
-# Common paths used across tests (mirrors conftest.py)
-APP_ROOT = "/opt/app-root"
-WORKDIR = f"{APP_ROOT}/src"
+from tests import APP_ROOT, WORKDIR
 
 
 @pytest.fixture(params=["python_container", "cuda_container"])

--- a/tests/test_cuda_image.py
+++ b/tests/test_cuda_image.py
@@ -62,19 +62,19 @@ def test_cuda_dir_exists(cuda_container):
 def test_libcudart_present(cuda_container):
     """Verify CUDA runtime library is present."""
     result = cuda_container.run("ldconfig -p | grep libcudart")
-    assert result.returncode == 0
+    assert result.returncode == 0, "libcudart.so not found - cuda-cudart package may be missing"
 
 
 def test_libcublas_present(cuda_container):
     """Verify cuBLAS library is present."""
     result = cuda_container.run("ldconfig -p | grep libcublas")
-    assert result.returncode == 0
+    assert result.returncode == 0, "libcublas.so not found - libcublas package may be missing"
 
 
 def test_libcudnn_present(cuda_container):
     """Verify cuDNN library is present."""
     result = cuda_container.run("ldconfig -p | grep libcudnn")
-    assert result.returncode == 0
+    assert result.returncode == 0, "libcudnn.so not found - libcudnn package may be missing"
 
 
 # --- CUDA Label Tests ---


### PR DESCRIPTION
Add assertion failure messages to older CUDA library tests (libcudart, libcublas, libcudnn) to match the style used in newer tests, and deduplicate APP_ROOT/WORKDIR constants by defining them once in tests/__init__.py.

Closes #92
