### PR TITLE
fix: use cu128 PyTorch wheels for CUDA 12.9

### DIFF
--- a/cuda/12.9/app.conf
+++ b/cuda/12.9/app.conf
@@ -74,6 +74,7 @@ NV_CUDNN_VERSION=9.8.0.87-1
 
 # -----------------------------------------------------------------------------
 # PyPI Indexes
+# Note: PyTorch deprecated cu129 in favor of cu130; cu128 wheels are compatible
 # -----------------------------------------------------------------------------
 PIP_INDEX_URL=https://pypi.org/simple
-PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu129
+PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu128


### PR DESCRIPTION
PyTorch deprecated cu129 builds in favor of cu130, so the cu129 wheel index has no stable PyTorch 2.9 wheels. Switch to cu128 wheels which are binary-compatible within the CUDA 12.x family.

Closes #94



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CUDA dependency configuration to align with current PyTorch wheel availability for improved installation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->