### PR TITLE
Improve test coverage: Add fix-permissions script and pip index-url v…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,11 @@ class ContainerRunner:
         result = self.run(f"test -f {shlex.quote(path)}")
         return result.returncode == 0
 
+    def file_executable(self, path: str) -> bool:
+        """Check if a file exists and is executable."""
+        result = self.run(f"test -x {shlex.quote(path)}")
+        return result.returncode == 0
+
     def dir_exists(self, path: str) -> bool:
         """Check if a directory exists."""
         result = self.run(f"test -d {shlex.quote(path)}")


### PR DESCRIPTION
Add fix-permissions script and pip index-url validation tests

- Add file_executable() helper to ContainerRunner
- Add test_fix_permissions_executable to verify /usr/local/bin/fix-permissions is present and executable in both Python and CUDA images
- Add test_pip_index_url_configured to assert pip global.index-url is actually set (not just that [global] exists)

Closes #88

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an executable-file check to the test runner to verify file executability.
  * Added tests to verify the presence and executability of the fix-permissions utility and to confirm pip global index URL is configured and retrievable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->