### PR TITLE
test: add pip/uv smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
               - 'tests/test_common.py'
               - 'tests/conftest.py'
               - 'tests/test_cuda_image.py'
+              - 'tests/__init__.py'
             any-python:
               - 'python/**/Containerfile'
               - 'python/**/app.conf'
@@ -48,7 +49,8 @@ jobs:
               - 'tests/test_common.py'
               - 'tests/conftest.py'
               - 'tests/test_python_image.py'  
-
+              - 'tests/__init__.py'
+              
       - name: Build CUDA version matrix
         id: cuda-versions
         if: steps.filter.outputs.any-cuda == 'true'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,25 @@
 """ODH Base Container Image Tests."""
 
+import re
+
 # Common paths used across tests
 APP_ROOT = "/opt/app-root"
 WORKDIR = f"{APP_ROOT}/src"
+
+# Matches the credential portion of URLs like https://token@host or
+# https://user:pass@host.  The ``/`` exclusion in the character class
+# prevents greedy over-redaction of URLs where ``@`` appears after a
+# path component (e.g. OCI references like
+# ``https://registry.example.com/image@sha256:...``).
+_URL_CREDENTIAL_RE = re.compile(r"(https?://)([^@\s/]+)@")
+
+
+def redact_url_credentials(text: str) -> str:
+    """Replace embedded credentials in URLs with ``****``.
+
+    pip only redacts ``user:password@host`` URLs; bare ``token@host``
+    credentials pass through unmasked.  This helper catches both forms
+    so that stderr can be safely included in assertion messages without
+    leaking secrets to CI logs.
+    """
+    return _URL_CREDENTIAL_RE.sub(r"\1****@", text)


### PR DESCRIPTION
Add test_pip_install_dry_run and test_uv_pip_compile_smoke to verify that pip and uv can resolve packages against the configured index-url.

Stderr embedded in assertion messages is masked of URL credentials before surfacing to CI logs. pip does not redact single-part tokens (e.g. https://token@host), only user:password@host format.

Closes #89

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added dry-run and smoke tests to verify package index access and dependency resolution during packaging flows.
  * Added a helper to redact URL credentials from test output to avoid leaking secrets in logs.

* **Chores**
  * Updated CI path filters so test helper changes are considered by relevant CI matrix runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->