### PR TITLE
chore: expand .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,3 +24,20 @@ Thumbs.db
 # Build artifacts
 *.log
 
+# Testing and development
+tests/
+.tox/
+.pytest_cache/
+
+# Python project/tooling config (not needed in image)
+pyproject.toml
+tox.ini
+.hadolint.yaml
+renovate.json
+
+# Python build artifacts
+*.egg-info/
+__pycache__/
+*.pyc
+*.pyo
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
               - 'scripts/fix-permissions'
               - 'scripts/build.sh'
               - 'requirements-build.txt'
+              - '.dockerignore'
               - 'tests/test_common.py'
               - 'tests/conftest.py'
               - 'tests/test_cuda_image.py'
@@ -46,6 +47,7 @@ jobs:
               - 'scripts/fix-permissions'
               - 'scripts/build.sh'
               - 'requirements-build.txt'
+              - '.dockerignore'
               - 'tests/test_common.py'
               - 'tests/conftest.py'
               - 'tests/test_python_image.py'  
@@ -58,7 +60,7 @@ jobs:
           CHANGED_FILES: ${{ steps.filter.outputs.any-cuda_files }}
         run: |
           # Check if common files changed (affects all versions)
-          if echo "$CHANGED_FILES" | grep -qE 'requirements-build\.txt|scripts/fix-permissions|scripts/build\.sh|tests/'; then
+          if echo "$CHANGED_FILES" | grep -qE 'requirements-build\.txt|scripts/fix-permissions|scripts/build\.sh|\.dockerignore|tests/'; then
             echo "Common files changed - including all CUDA versions"
             # Get all available CUDA versions from directory structure
             VERSIONS=$(find cuda -maxdepth 1 -type d -name '[0-9]*.[0-9]*' \
@@ -84,7 +86,7 @@ jobs:
           CHANGED_FILES: ${{ steps.filter.outputs.any-python_files }}
         run: |
           # Check if common files changed (affects all versions)
-          if echo "$CHANGED_FILES" | grep -qE 'requirements-build\.txt|scripts/fix-permissions|scripts/build\.sh|tests/'; then
+          if echo "$CHANGED_FILES" | grep -qE 'requirements-build\.txt|scripts/fix-permissions|scripts/build\.sh|\.dockerignore|tests/'; then
             echo "Common files changed - including all Python versions"
             # Get all available Python versions from directory structure
             VERSIONS=$(find python -maxdepth 1 -type d -name '[0-9]*.[0-9]*' \

--- a/.tekton/odh-midstream-cuda-base-12-8-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-8-pull-request.yaml
@@ -13,6 +13,7 @@ metadata:
         'cuda/12.8/**'.pathChanged() ||
         'requirements-build.txt'.pathChanged() ||
         'scripts/fix-permissions'.pathChanged() ||
+        '.dockerignore'.pathChanged() ||
         '.tekton/odh-midstream-cuda-base-12-8-pull-request.yaml'.pathChanged()
       )
   creationTimestamp: null

--- a/.tekton/odh-midstream-cuda-base-12-8-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-8-push.yaml
@@ -12,6 +12,7 @@ metadata:
         'cuda/12.8/**'.pathChanged() ||
         'requirements-build.txt'.pathChanged() ||
         'scripts/fix-permissions'.pathChanged() ||
+        '.dockerignore'.pathChanged() ||
         '.tekton/odh-midstream-cuda-base-12-8-push.yaml'.pathChanged()
       )
   creationTimestamp: null

--- a/.tekton/odh-midstream-cuda-base-12-9-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-9-pull-request.yaml
@@ -13,6 +13,7 @@ metadata:
         'cuda/12.9/**'.pathChanged() ||
         'requirements-build.txt'.pathChanged() ||
         'scripts/fix-permissions'.pathChanged() ||
+        '.dockerignore'.pathChanged() ||
         '.tekton/odh-midstream-cuda-base-12-9-pull-request.yaml'.pathChanged()
       )
   creationTimestamp: null

--- a/.tekton/odh-midstream-cuda-base-12-9-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-9-push.yaml
@@ -12,6 +12,7 @@ metadata:
         'cuda/12.9/**'.pathChanged() ||
         'requirements-build.txt'.pathChanged() ||
         'scripts/fix-permissions'.pathChanged() ||
+        '.dockerignore'.pathChanged() ||
         '.tekton/odh-midstream-cuda-base-12-9-push.yaml'.pathChanged()
       )
   creationTimestamp: null

--- a/.tekton/odh-midstream-cuda-base-13-0-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-0-pull-request.yaml
@@ -13,6 +13,7 @@ metadata:
         'cuda/13.0/**'.pathChanged() ||
         'requirements-build.txt'.pathChanged() ||
         'scripts/fix-permissions'.pathChanged() ||
+        '.dockerignore'.pathChanged() ||
         '.tekton/odh-midstream-cuda-base-13-0-pull-request.yaml'.pathChanged()
       )
   creationTimestamp: null

--- a/.tekton/odh-midstream-cuda-base-13-0-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-0-push.yaml
@@ -12,6 +12,7 @@ metadata:
         'cuda/13.0/**'.pathChanged() ||
         'requirements-build.txt'.pathChanged() ||
         'scripts/fix-permissions'.pathChanged() ||
+        '.dockerignore'.pathChanged() ||
         '.tekton/odh-midstream-cuda-base-13-0-push.yaml'.pathChanged()
       )
   creationTimestamp: null

--- a/.tekton/odh-midstream-cuda-base-13-1-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-1-pull-request.yaml
@@ -13,6 +13,7 @@ metadata:
         'cuda/13.1/**'.pathChanged() ||
         'requirements-build.txt'.pathChanged() ||
         'scripts/fix-permissions'.pathChanged() ||
+        '.dockerignore'.pathChanged() ||
         '.tekton/odh-midstream-cuda-base-13-1-pull-request.yaml'.pathChanged()
       )
   creationTimestamp: null

--- a/.tekton/odh-midstream-cuda-base-13-1-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-1-push.yaml
@@ -12,6 +12,7 @@ metadata:
         'cuda/13.1/**'.pathChanged() ||
         'requirements-build.txt'.pathChanged() ||
         'scripts/fix-permissions'.pathChanged() ||
+        '.dockerignore'.pathChanged() ||
         '.tekton/odh-midstream-cuda-base-13-1-push.yaml'.pathChanged()
       )
   creationTimestamp: null

--- a/.tekton/odh-midstream-python-base-3-12-pull-request.yaml
+++ b/.tekton/odh-midstream-python-base-3-12-pull-request.yaml
@@ -13,6 +13,7 @@ metadata:
         'python/3.12/**'.pathChanged() ||
         'requirements-build.txt'.pathChanged() ||
         'scripts/fix-permissions'.pathChanged() ||
+        '.dockerignore'.pathChanged() ||
         '.tekton/odh-midstream-python-base-3-12-pull-request.yaml'.pathChanged()
       )
   creationTimestamp: null

--- a/.tekton/odh-midstream-python-base-3-12-push.yaml
+++ b/.tekton/odh-midstream-python-base-3-12-push.yaml
@@ -12,6 +12,7 @@ metadata:
         'python/3.12/**'.pathChanged() ||
         'requirements-build.txt'.pathChanged() ||
         'scripts/fix-permissions'.pathChanged() ||
+        '.dockerignore'.pathChanged() ||
         '.tekton/odh-midstream-python-base-3-12-push.yaml'.pathChanged()
       )
   creationTimestamp: null


### PR DESCRIPTION
Exclude additional development and test files from the container build context to improve build cache effectiveness and reduce build time.

Added .dockerignore to CI/Tekton path filters so changes to this file
trigger image builds, preventing silent build breakage from bad edits.

Closes #90 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Exclude development, testing, and Python build artifacts from container image builds to produce leaner, cleaner images.
  * CI and pipeline triggers updated so changes to the container-image ignore configuration now re-run affected build and test pipelines, ensuring images and tests reflect updated exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->