### PR TITLE
test: make OCI label tests symmetric across Python and CUDA images

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -185,6 +185,35 @@ def test_uv_system_python(container):
     assert container.get_env("UV_SYSTEM_PYTHON") == "1"
 
 
+# --- OCI Label Tests ---
+
+
+def test_name_label(container):
+    """Verify name label is set."""
+    labels = container.get_labels()
+    assert labels.get("name"), "name label should be set and non-empty"
+
+
+def test_version_label(container):
+    """Verify version label is set."""
+    labels = container.get_labels()
+    assert labels.get("version"), "version label should be set and non-empty"
+
+
+def test_k8s_display_name_label(container):
+    """Verify Kubernetes display name label is set."""
+    labels = container.get_labels()
+    assert labels.get("io.k8s.display-name"), "Kubernetes display name label should be set"
+
+
+def test_opencontainers_source_label(container):
+    """Verify OCI source label points to GitHub."""
+    labels = container.get_labels()
+    source = labels.get("org.opencontainers.image.source", "")
+    assert source, "OCI source label should be set"
+    assert "github.com" in source, f"OCI source should point to GitHub, got: {source}"
+
+
 # --- Security Tests ---
 
 

--- a/tests/test_python_image.py
+++ b/tests/test_python_image.py
@@ -8,33 +8,7 @@ import os
 
 import pytest
 
-# --- OCI Label Tests ---
-
-
-def test_name_label(python_container):
-    """Verify name label is set."""
-    labels = python_container.get_labels()
-    assert labels.get("name"), "name label should be set and non-empty"
-
-
-def test_version_label(python_container):
-    """Verify version label is set."""
-    labels = python_container.get_labels()
-    assert labels.get("version"), "version label should be set and non-empty"
-
-
-def test_k8s_display_name_label(python_container):
-    """Verify Kubernetes display name label is set."""
-    labels = python_container.get_labels()
-    assert labels.get("io.k8s.display-name"), "Kubernetes display name label should be set"
-
-
-def test_opencontainers_source_label(python_container):
-    """Verify OCI source label points to GitHub."""
-    labels = python_container.get_labels()
-    source = labels.get("org.opencontainers.image.source", "")
-    assert source, "OCI source label should be set"
-    assert "github.com" in source, f"OCI source should point to GitHub, got: {source}"
+# --- Python-Specific Label Tests ---
 
 
 def test_accelerator_label_cpu(python_container):


### PR DESCRIPTION
Move shared OCI label assertions (name, version, io.k8s.display-name, org.opencontainers.image.source) from test_python_image.py into test_common.py so both images are validated equally via the parameterized `container` fixture.

Keep image-specific label tests in their respective files:
- test_python_image.py: accelerator=cpu, python version
- test_cuda_image.py: cuda version, accelerator=cuda

Closes #87 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
