### PR TITLE
test: read Python version from OCI label instead of hardcoding

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -19,10 +19,15 @@ def container(request):
 
 
 def test_python_version(container):
-    """Verify Python 3.12 is installed and working."""
+    """Verify installed Python version matches the com.opendatahub.python label."""
+    expected = container.get_labels().get("com.opendatahub.python", "")
+    assert expected, "com.opendatahub.python label must be set"
+
     result = container.run("python --version")
     assert result.returncode == 0
-    assert "Python 3.12" in result.stdout
+    assert f"Python {expected}" in result.stdout, (
+        f"Expected Python {expected} (from label), got: {result.stdout.strip()}"
+    )
 
 
 def test_pip_available(container):


### PR DESCRIPTION
Replace the hardcoded "Python 3.12" assertion in test_python_version with a dynamic lookup of the com.opendatahub.python image label. This makes the test self-contained and prevents breakage when a new Python version is added.

Closes #105

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved container validation tests to dynamically retrieve expected Python versions from container labels instead of using hardcoded values, with enhanced assertion messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->