### PR TITLE
ci: create calendar version tags on push

### DIFF
--- a/.tekton/pipelines/push.yaml
+++ b/.tekton/pipelines/push.yaml
@@ -571,7 +571,7 @@ spec:
         script: |
           #!/usr/bin/env bash
           set -euo pipefail
-          VERSION_TAG=$(bash /var/workdir/source/scripts/generate-tag.sh /var/workdir/source)
+          VERSION_TAG=$(bash /var/workdir/source/scripts/generate-tag.sh HEAD /var/workdir/source)
           echo -n "${VERSION_TAG}" > /tekton/results/VERSION_TAG
           echo "Generated version tag: ${VERSION_TAG}"
   - name: apply-tags

--- a/.tekton/pipelines/push.yaml
+++ b/.tekton/pipelines/push.yaml
@@ -538,14 +538,55 @@ spec:
       operator: in
       values:
       - "false"
+  - name: generate-image-tag
+    params:
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskSpec:
+      params:
+      - name: SOURCE_ARTIFACT
+        type: string
+      results:
+      - name: VERSION_TAG
+        type: string
+      volumes:
+      - name: workdir
+        emptyDir: {}
+      steps:
+      - name: use-trusted-artifact
+        image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
+        args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        volumeMounts:
+        - mountPath: /var/workdir
+          name: workdir
+      - name: generate-tag
+        image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
+        volumeMounts:
+        - mountPath: /var/workdir
+          name: workdir
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          VERSION_TAG=$(bash /var/workdir/source/scripts/generate-tag.sh /var/workdir/source)
+          echo -n "${VERSION_TAG}" > /tekton/results/VERSION_TAG
+          echo "Generated version tag: ${VERSION_TAG}"
   - name: apply-tags
     params:
     - name: IMAGE_URL
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: IMAGE_DIGEST
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: ADDITIONAL_TAGS
+      value:
+      - $(tasks.generate-image-tag.results.VERSION_TAG)
+      - latest
     runAfter:
     - build-image-index
+    - generate-image-tag
     taskRef:
       params:
       - name: name

--- a/.tekton/pipelines/push.yaml
+++ b/.tekton/pipelines/push.yaml
@@ -578,6 +578,7 @@ spec:
         script: |
           #!/usr/bin/env bash
           set -euo pipefail
+          git config --global --add safe.directory /var/workdir/source
           VERSION_TAG=$(bash /var/workdir/source/scripts/generate-tag.sh HEAD /var/workdir/source)
           echo -n "${VERSION_TAG}" > /tekton/results/VERSION_TAG
           echo "Generated version tag: ${VERSION_TAG}"

--- a/.tekton/pipelines/push.yaml
+++ b/.tekton/pipelines/push.yaml
@@ -595,6 +595,11 @@ spec:
     runAfter:
     - build-image-index
     - generate-image-tag
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
     taskRef:
       params:
       - name: name

--- a/.tekton/pipelines/push.yaml
+++ b/.tekton/pipelines/push.yaml
@@ -125,6 +125,8 @@ spec:
       value: $(params.git-url)
     - name: revision
       value: $(params.revision)
+    - name: depth
+      value: "0"
     - name: ociStorage
       value: $(params.output-image).git
     - name: ociArtifactExpiresAfter
@@ -544,6 +546,11 @@ spec:
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     runAfter:
     - build-image-index
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
     taskSpec:
       params:
       - name: SOURCE_ARTIFACT

--- a/scripts/generate-tag.sh
+++ b/scripts/generate-tag.sh
@@ -2,13 +2,14 @@
 
 set -euo pipefail
 
-SOURCE_DIR="${1:-.}"
+COMMIT="${1:-HEAD}"
+SOURCE_DIR="${2:-.}"
 MAJOR=1
 
-COMMIT_DATE=$(TZ=UTC git -C "${SOURCE_DIR}" log -1 --format="%ad" --date=format-local:"%Y%m%d" HEAD)
-# Count commits on the same day that are ancestors of HEAD (i.e., came before it).
-# This gives a deterministic, sequential build number from git history — no registry access needed.
-BUILD_NUM=$(TZ=UTC git -C "${SOURCE_DIR}" log HEAD^ --format="%ad" --date=format-local:"%Y%m%d" \
+COMMIT_DATE=$(TZ=UTC git -C "${SOURCE_DIR}" log -1 --format="%ad" --date=format-local:"%Y%m%d" "${COMMIT}")
+# Count first-parent commits on the same day that came before COMMIT.
+# --first-parent follows only the main line, so BUILD_NUM reflects merge count, not branch activity.
+BUILD_NUM=$(TZ=UTC git -C "${SOURCE_DIR}" log --first-parent "${COMMIT}^" --format="%ad" --date=format-local:"%Y%m%d" \
   | grep -c "^${COMMIT_DATE}$")
 
 echo -n "${MAJOR}.${COMMIT_DATE}.${BUILD_NUM}"

--- a/scripts/generate-tag.sh
+++ b/scripts/generate-tag.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SOURCE_DIR="${1:-.}"
+MAJOR=1
+
+COMMIT_DATE=$(TZ=UTC git -C "${SOURCE_DIR}" log -1 --format="%ad" --date=format-local:"%Y%m%d" HEAD)
+# Count commits on the same day that are ancestors of HEAD (i.e., came before it).
+# This gives a deterministic, sequential build number from git history — no registry access needed.
+BUILD_NUM=$(TZ=UTC git -C "${SOURCE_DIR}" log HEAD^ --format="%ad" --date=format-local:"%Y%m%d" \
+  | grep -c "^${COMMIT_DATE}$")
+
+echo -n "${MAJOR}.${COMMIT_DATE}.${BUILD_NUM}"

--- a/scripts/generate-tag.sh
+++ b/scripts/generate-tag.sh
@@ -7,9 +7,12 @@ SOURCE_DIR="${2:-.}"
 MAJOR=1
 
 COMMIT_DATE=$(TZ=UTC git -C "${SOURCE_DIR}" log -1 --format="%ad" --date=format-local:"%Y%m%d" "${COMMIT}")
-# Count first-parent commits on the same day that came before COMMIT.
-# --first-parent follows only the main line, so BUILD_NUM reflects merge count, not branch activity.
-BUILD_NUM=$(TZ=UTC git -C "${SOURCE_DIR}" log --first-parent "${COMMIT}^" --format="%ad" --date=format-local:"%Y%m%d" \
-  | grep -c "^${COMMIT_DATE}$")
+
+if git -C "${SOURCE_DIR}" rev-parse --verify "${COMMIT}^" >/dev/null 2>&1; then
+  BUILD_NUM=$(TZ=UTC git -C "${SOURCE_DIR}" log --first-parent "${COMMIT}^" --format="%ad" --date=format-local:"%Y%m%d" \
+    | grep -c "^${COMMIT_DATE}$" || true)
+else
+  BUILD_NUM=0
+fi
 
 echo -n "${MAJOR}.${COMMIT_DATE}.${BUILD_NUM}"


### PR DESCRIPTION
- adds a script to generate a new tag in format: "1.YYYYMMDD.N". (1.20260305.0)
- adds additional tag on push pipelines
- closes #99

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated image tag generation added, producing stable, ordered tags based on commit date and build sequence.

* **Chores**
  * CI/CD updated to compute and version images during builds and apply the generated tag alongside "latest".
  * Pipeline ordering adjusted so tagging runs as part of the build flow to ensure tags reflect the built image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->