### PR TITLE
fix(tox): pass PYTHON_VERSION and CUDA_VERSION to test env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,8 @@ deps = .[test]
 passenv =
     PYTHON_IMAGE
     CUDA_IMAGE
+    PYTHON_VERSION
+    CUDA_VERSION
 commands =
     pytest tests/ {posargs:-v}
 


### PR DESCRIPTION
tox's environment isolation strips environment variables not listed in passenv, causing version validation tests to silently skip even when these variables are explicitly set in the shell.

Fixes #104 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test environment configuration to properly propagate Python and CUDA version environment variables during test execution, ensuring consistent testing across different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->