### PR TITLE
Add UV_TORCH_BACKEND to CUDA images for uv PyTorch wheel selection

### DIFF
--- a/Containerfile.cuda.template
+++ b/Containerfile.cuda.template
@@ -191,6 +191,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 ARG PIP_INDEX_URL=https://pypi.org/simple
 ARG PIP_EXTRA_INDEX_URL
+ARG UV_TORCH_BACKEND=
 
 # pip configuration (system-wide) - must be created before installing uv
 RUN mkdir -p /etc/pip && \
@@ -208,10 +209,14 @@ RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)
+# Note: PIP_EXTRA_INDEX_URL is intentionally omitted from uv.toml because
+# UV_TORCH_BACKEND is uv's native mechanism for PyTorch CUDA wheel resolution.
+# torch-backend is written to uv.toml (not ENV) to avoid uv erroring on empty values.
+# Downstream builds can disable by omitting UV_TORCH_BACKEND or rebuilding uv.toml.
 RUN mkdir -p /etc/uv && \
     { echo "[pip]"; \
       echo "index-url = \"${PIP_INDEX_URL}\""; \
-      [ -n "${PIP_EXTRA_INDEX_URL}" ] && echo "extra-index-url = [\"${PIP_EXTRA_INDEX_URL}\"]"; \
+      [ -n "${UV_TORCH_BACKEND}" ] && echo "torch-backend = \"${UV_TORCH_BACKEND}\""; \
       true; \
     } > /etc/uv/uv.toml
 ENV UV_CONFIG_FILE=/etc/uv/uv.toml
@@ -312,6 +317,7 @@ WORKDIR /opt/app-root/src
 #   podman build -t myapp:rhoai \
 #     --build-arg PIP_INDEX_URL=https://aipcc.internal/simple \
 #     --build-arg PIP_EXTRA_INDEX_URL="" \
+#     --build-arg UV_TORCH_BACKEND= \
 #     .
 #
 # -----------------------------------------------------------------------------

--- a/cuda/12.8/Containerfile
+++ b/cuda/12.8/Containerfile
@@ -191,6 +191,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 ARG PIP_INDEX_URL=https://pypi.org/simple
 ARG PIP_EXTRA_INDEX_URL
+ARG UV_TORCH_BACKEND=
 
 # pip configuration (system-wide) - must be created before installing uv
 RUN mkdir -p /etc/pip && \
@@ -208,10 +209,14 @@ RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)
+# Note: PIP_EXTRA_INDEX_URL is intentionally omitted from uv.toml because
+# UV_TORCH_BACKEND is uv's native mechanism for PyTorch CUDA wheel resolution.
+# torch-backend is written to uv.toml (not ENV) to avoid uv erroring on empty values.
+# Downstream builds can disable by omitting UV_TORCH_BACKEND or rebuilding uv.toml.
 RUN mkdir -p /etc/uv && \
     { echo "[pip]"; \
       echo "index-url = \"${PIP_INDEX_URL}\""; \
-      [ -n "${PIP_EXTRA_INDEX_URL}" ] && echo "extra-index-url = [\"${PIP_EXTRA_INDEX_URL}\"]"; \
+      [ -n "${UV_TORCH_BACKEND}" ] && echo "torch-backend = \"${UV_TORCH_BACKEND}\""; \
       true; \
     } > /etc/uv/uv.toml
 ENV UV_CONFIG_FILE=/etc/uv/uv.toml
@@ -312,6 +317,7 @@ WORKDIR /opt/app-root/src
 #   podman build -t myapp:rhoai \
 #     --build-arg PIP_INDEX_URL=https://aipcc.internal/simple \
 #     --build-arg PIP_EXTRA_INDEX_URL="" \
+#     --build-arg UV_TORCH_BACKEND= \
 #     .
 #
 # -----------------------------------------------------------------------------

--- a/cuda/12.8/app.conf
+++ b/cuda/12.8/app.conf
@@ -77,3 +77,10 @@ NV_CUDNN_VERSION=9.8.0.87-1
 # -----------------------------------------------------------------------------
 PIP_INDEX_URL=https://pypi.org/simple
 PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu128
+
+# -----------------------------------------------------------------------------
+# uv PyTorch Backend
+# Tells uv which CUDA variant to select for PyTorch wheels (uv pip install).
+# https://docs.astral.sh/uv/guides/integration/pytorch/
+# -----------------------------------------------------------------------------
+UV_TORCH_BACKEND=cu128

--- a/cuda/12.9/Containerfile
+++ b/cuda/12.9/Containerfile
@@ -191,6 +191,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 ARG PIP_INDEX_URL=https://pypi.org/simple
 ARG PIP_EXTRA_INDEX_URL
+ARG UV_TORCH_BACKEND=
 
 # pip configuration (system-wide) - must be created before installing uv
 RUN mkdir -p /etc/pip && \
@@ -208,10 +209,14 @@ RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)
+# Note: PIP_EXTRA_INDEX_URL is intentionally omitted from uv.toml because
+# UV_TORCH_BACKEND is uv's native mechanism for PyTorch CUDA wheel resolution.
+# torch-backend is written to uv.toml (not ENV) to avoid uv erroring on empty values.
+# Downstream builds can disable by omitting UV_TORCH_BACKEND or rebuilding uv.toml.
 RUN mkdir -p /etc/uv && \
     { echo "[pip]"; \
       echo "index-url = \"${PIP_INDEX_URL}\""; \
-      [ -n "${PIP_EXTRA_INDEX_URL}" ] && echo "extra-index-url = [\"${PIP_EXTRA_INDEX_URL}\"]"; \
+      [ -n "${UV_TORCH_BACKEND}" ] && echo "torch-backend = \"${UV_TORCH_BACKEND}\""; \
       true; \
     } > /etc/uv/uv.toml
 ENV UV_CONFIG_FILE=/etc/uv/uv.toml
@@ -312,6 +317,7 @@ WORKDIR /opt/app-root/src
 #   podman build -t myapp:rhoai \
 #     --build-arg PIP_INDEX_URL=https://aipcc.internal/simple \
 #     --build-arg PIP_EXTRA_INDEX_URL="" \
+#     --build-arg UV_TORCH_BACKEND= \
 #     .
 #
 # -----------------------------------------------------------------------------

--- a/cuda/12.9/app.conf
+++ b/cuda/12.9/app.conf
@@ -74,7 +74,18 @@ NV_CUDNN_VERSION=9.8.0.87-1
 
 # -----------------------------------------------------------------------------
 # PyPI Indexes
-# Note: PyTorch deprecated cu129 in favor of cu130; cu128 wheels are compatible
+# Note: PyTorch does not publish cu129 wheels. Using cu128 instead, which is
+# compatible because CUDA minor versions are backwards-compatible within the
+# same major version. Verified: cu128 wheels install and work on CUDA 12.9.
+# See: https://download.pytorch.org/whl/ (cu129 index does not exist)
 # -----------------------------------------------------------------------------
 PIP_INDEX_URL=https://pypi.org/simple
 PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu128
+
+# -----------------------------------------------------------------------------
+# uv PyTorch Backend
+# Tells uv which CUDA variant to select for PyTorch wheels (uv pip install).
+# Uses cu128 for the same reason as PIP_EXTRA_INDEX_URL above (no cu129 wheels).
+# https://docs.astral.sh/uv/guides/integration/pytorch/
+# -----------------------------------------------------------------------------
+UV_TORCH_BACKEND=cu128

--- a/cuda/13.0/Containerfile
+++ b/cuda/13.0/Containerfile
@@ -191,6 +191,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 ARG PIP_INDEX_URL=https://pypi.org/simple
 ARG PIP_EXTRA_INDEX_URL
+ARG UV_TORCH_BACKEND=
 
 # pip configuration (system-wide) - must be created before installing uv
 RUN mkdir -p /etc/pip && \
@@ -208,10 +209,14 @@ RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)
+# Note: PIP_EXTRA_INDEX_URL is intentionally omitted from uv.toml because
+# UV_TORCH_BACKEND is uv's native mechanism for PyTorch CUDA wheel resolution.
+# torch-backend is written to uv.toml (not ENV) to avoid uv erroring on empty values.
+# Downstream builds can disable by omitting UV_TORCH_BACKEND or rebuilding uv.toml.
 RUN mkdir -p /etc/uv && \
     { echo "[pip]"; \
       echo "index-url = \"${PIP_INDEX_URL}\""; \
-      [ -n "${PIP_EXTRA_INDEX_URL}" ] && echo "extra-index-url = [\"${PIP_EXTRA_INDEX_URL}\"]"; \
+      [ -n "${UV_TORCH_BACKEND}" ] && echo "torch-backend = \"${UV_TORCH_BACKEND}\""; \
       true; \
     } > /etc/uv/uv.toml
 ENV UV_CONFIG_FILE=/etc/uv/uv.toml
@@ -312,6 +317,7 @@ WORKDIR /opt/app-root/src
 #   podman build -t myapp:rhoai \
 #     --build-arg PIP_INDEX_URL=https://aipcc.internal/simple \
 #     --build-arg PIP_EXTRA_INDEX_URL="" \
+#     --build-arg UV_TORCH_BACKEND= \
 #     .
 #
 # -----------------------------------------------------------------------------

--- a/cuda/13.0/app.conf
+++ b/cuda/13.0/app.conf
@@ -77,3 +77,10 @@ NV_CUDNN_VERSION=9.15.1.9-1
 # -----------------------------------------------------------------------------
 PIP_INDEX_URL=https://pypi.org/simple
 PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu130
+
+# -----------------------------------------------------------------------------
+# uv PyTorch Backend
+# Tells uv which CUDA variant to select for PyTorch wheels (uv pip install).
+# https://docs.astral.sh/uv/guides/integration/pytorch/
+# -----------------------------------------------------------------------------
+UV_TORCH_BACKEND=cu130

--- a/cuda/13.1/Containerfile
+++ b/cuda/13.1/Containerfile
@@ -191,6 +191,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 ARG PIP_INDEX_URL=https://pypi.org/simple
 ARG PIP_EXTRA_INDEX_URL
+ARG UV_TORCH_BACKEND=
 
 # pip configuration (system-wide) - must be created before installing uv
 RUN mkdir -p /etc/pip && \
@@ -208,10 +209,14 @@ RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)
+# Note: PIP_EXTRA_INDEX_URL is intentionally omitted from uv.toml because
+# UV_TORCH_BACKEND is uv's native mechanism for PyTorch CUDA wheel resolution.
+# torch-backend is written to uv.toml (not ENV) to avoid uv erroring on empty values.
+# Downstream builds can disable by omitting UV_TORCH_BACKEND or rebuilding uv.toml.
 RUN mkdir -p /etc/uv && \
     { echo "[pip]"; \
       echo "index-url = \"${PIP_INDEX_URL}\""; \
-      [ -n "${PIP_EXTRA_INDEX_URL}" ] && echo "extra-index-url = [\"${PIP_EXTRA_INDEX_URL}\"]"; \
+      [ -n "${UV_TORCH_BACKEND}" ] && echo "torch-backend = \"${UV_TORCH_BACKEND}\""; \
       true; \
     } > /etc/uv/uv.toml
 ENV UV_CONFIG_FILE=/etc/uv/uv.toml
@@ -312,6 +317,7 @@ WORKDIR /opt/app-root/src
 #   podman build -t myapp:rhoai \
 #     --build-arg PIP_INDEX_URL=https://aipcc.internal/simple \
 #     --build-arg PIP_EXTRA_INDEX_URL="" \
+#     --build-arg UV_TORCH_BACKEND= \
 #     .
 #
 # -----------------------------------------------------------------------------

--- a/cuda/13.1/app.conf
+++ b/cuda/13.1/app.conf
@@ -74,8 +74,15 @@ NV_CUDNN_VERSION=9.17.1.4-1
 
 # -----------------------------------------------------------------------------
 # PyPI Indexes
-# Note: Using cu130 for CUDA 13.1 - PyTorch doesn't publish cu131 wheels
-# CUDA minor versions within the same major are compatible
+# Note: Using cu130 for CUDA 13.1 - PyTorch doesn't publish cu131 wheels.
+# CUDA minor versions within the same major are compatible.
 # -----------------------------------------------------------------------------
 PIP_INDEX_URL=https://pypi.org/simple
 PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu130
+
+# -----------------------------------------------------------------------------
+# uv PyTorch Backend
+# Tells uv which CUDA variant to select for PyTorch wheels (uv pip install).
+# https://docs.astral.sh/uv/guides/integration/pytorch/
+# -----------------------------------------------------------------------------
+UV_TORCH_BACKEND=cu130

--- a/docs/RATIONALE.md
+++ b/docs/RATIONALE.md
@@ -168,6 +168,7 @@ podman build -t myapp:odh .
 podman build -t myapp:rhoai \
   --build-arg PIP_INDEX_URL=https://aipcc.internal/simple \
   --build-arg PIP_EXTRA_INDEX_URL="" \
+  --build-arg UV_TORCH_BACKEND= \
   .
 ```
 
@@ -177,5 +178,6 @@ The following build args are expected to change between streams:
 |---|---|---|
 | `BASE_IMAGE` | Public image (CentOS, UBI) | Internal AIPCC image |
 | `PIP_INDEX_URL` | `https://pypi.org/simple` | Internal index URL |
-| `PIP_EXTRA_INDEX_URL` | PyTorch public index | Empty or internal |
+| `PIP_EXTRA_INDEX_URL` | PyTorch public index | Empty (disabled) |
+| `UV_TORCH_BACKEND` | CUDA backend (e.g., `cu128`) | Empty (omitted from uv.toml) |
 

--- a/scripts/generate-containerfile.sh
+++ b/scripts/generate-containerfile.sh
@@ -27,6 +27,10 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
+# Global options (set by main via flag parsing)
+TORCH_BACKEND=""
+SKIP_PYTORCH_CHECK=false
+
 log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
@@ -78,6 +82,31 @@ check_existing_version() {
 # Escape BRE pattern-side metacharacters. Safe for version strings (X.Y) only.
 sed_escape() {
     printf '%s' "$1" | sed 's/[.[\*^$/]/\\&/g'
+}
+
+# Check if a PyTorch wheel index exists for a given CUDA backend (e.g., cu128, cu130).
+# Returns 0 if the index exists (HTTP 200), 1 otherwise.
+check_pytorch_wheel_index() {
+    local backend="$1"
+    local url="https://download.pytorch.org/whl/${backend}/"
+    local http_code
+
+    local curl_stderr
+    curl_stderr=$(mktemp)
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${url}" 2>"${curl_stderr}") || {
+        log_error "Network error: could not reach ${url}"
+        [[ -s "${curl_stderr}" ]] && log_error "curl: $(cat "${curl_stderr}")"
+        rm -f "${curl_stderr}"
+        log_error "Check your internet connection or re-run with --skip-pytorch-check"
+        return 1
+    }
+    rm -f "${curl_stderr}"
+
+    if [[ "${http_code}" == "200" ]]; then
+        return 0
+    else
+        return 1
+    fi
 }
 
 # Find the latest existing version directory for a given type (e.g., cuda, python)
@@ -221,13 +250,61 @@ create_cuda_appconf() {
         fi
     done
 
+    # Validate and update PyTorch wheel index for the new CUDA version
+    local new_torch_backend
+    if [[ -n "${TORCH_BACKEND}" ]]; then
+        new_torch_backend="${TORCH_BACKEND}"
+        log_info "Using user-specified torch backend: ${new_torch_backend}"
+    else
+        new_torch_backend="cu${new_major}${new_minor}"
+    fi
+    local new_torch_index="https://download.pytorch.org/whl/${new_torch_backend}"
+
+    if [[ "${SKIP_PYTORCH_CHECK}" == "true" && -z "${TORCH_BACKEND}" ]]; then
+        log_error "--skip-pytorch-check requires --torch-backend to avoid using an"
+        log_error "auto-derived backend that may not exist (e.g., cu131 for CUDA 13.1"
+        log_error "when PyTorch only publishes cu130)."
+        log_error ""
+        log_error "Example: $0 cuda ${new_version} --skip-pytorch-check --torch-backend cu${new_major}${new_minor}"
+        exit 1
+    elif [[ "${SKIP_PYTORCH_CHECK}" == "true" ]]; then
+        log_warn "Skipping PyTorch wheel index check (--skip-pytorch-check)"
+        log_warn "Using backend ${new_torch_backend} without online validation"
+    else
+        log_info "Checking PyTorch wheel index for ${new_torch_backend}..."
+        if ! check_pytorch_wheel_index "${new_torch_backend}"; then
+            log_error "No PyTorch wheel index found for ${new_torch_backend}"
+            log_error "URL checked: ${new_torch_index}/"
+            log_error "PyTorch does not publish wheels for every CUDA minor version."
+            log_error "Check available indexes at: https://download.pytorch.org/whl/"
+            log_error ""
+            log_error "To use an older CUDA wheel index, re-run with:"
+            log_error "  $0 cuda ${new_version} --torch-backend <backend>"
+            log_error "  Example: $0 cuda ${new_version} --torch-backend cu${new_major}$((new_minor > 0 ? new_minor - 1 : 0))"
+            log_error ""
+            log_error "To skip this check entirely (offline/air-gapped), re-run with:"
+            log_error "  $0 cuda ${new_version} --skip-pytorch-check --torch-backend <backend>"
+            # Clean up only the files created by this run
+            rm -f "${new_conf}" "${output_dir}/Containerfile"
+            rmdir "${output_dir}" 2>/dev/null || true
+            exit 1
+        fi
+        log_info "PyTorch wheel index found: ${new_torch_index}"
+    fi
+
+    # Update PIP_EXTRA_INDEX_URL and UV_TORCH_BACKEND in app.conf
+    sed -i "s|^PIP_EXTRA_INDEX_URL=.*|PIP_EXTRA_INDEX_URL=${new_torch_index}|" "${new_conf}"
+    sed -i "s|^UV_TORCH_BACKEND=.*|UV_TORCH_BACKEND=${new_torch_backend}|" "${new_conf}"
+    log_info "Updated PIP_EXTRA_INDEX_URL to ${new_torch_index}"
+    log_info "Updated UV_TORCH_BACKEND to ${new_torch_backend}"
+
     log_info "Generated: ${new_conf} (from cuda/${old_version}/app.conf)"
     log_warn "NVIDIA-specific version values are marked with TODO and must be updated"
     log_warn "See: https://gitlab.com/nvidia/container-images/cuda/-/tree/master/dist/${new_version}.x"
 }
 
 print_usage() {
-    echo "Usage: $0 <cuda|python> <version>"
+    echo "Usage: $0 <cuda|python> <version> [options]"
     echo ""
     echo "Generate a version-specific Containerfile and starter app.conf from template."
     echo ""
@@ -235,10 +312,20 @@ print_usage() {
     echo "  cuda <version>    Generate CUDA Containerfile + app.conf (e.g., 12.9, 13.0)"
     echo "  python <version>  Generate Python Containerfile + app.conf (e.g., 3.12, 3.13)"
     echo ""
+    echo "Options (cuda only):"
+    echo "  --torch-backend <backend>  Use a specific PyTorch CUDA backend (e.g., cu128, cu130)"
+    echo "                             instead of auto-deriving from the CUDA version."
+    echo "                             Useful when PyTorch doesn't publish wheels for every"
+    echo "                             CUDA minor version (e.g., CUDA 13.1 uses cu130)."
+    echo "  --skip-pytorch-check       Skip the PyTorch wheel index HTTP validation."
+    echo "                             Requires --torch-backend to avoid silently using"
+    echo "                             an incorrect auto-derived backend."
+    echo ""
     echo "Examples:"
-    echo "  $0 cuda 12.9      # Generate cuda/12.9/{Containerfile,app.conf}"
-    echo "  $0 cuda 13.0      # Generate cuda/13.0/{Containerfile,app.conf}"
-    echo "  $0 python 3.13    # Generate python/3.13/{Containerfile,app.conf}"
+    echo "  $0 cuda 12.9                          # Auto-derives cu129, validates online"
+    echo "  $0 cuda 13.1 --torch-backend cu130    # Use cu130 for CUDA 13.1"
+    echo "  $0 cuda 13.2 --skip-pytorch-check --torch-backend cu132  # Skip online check (offline)"
+    echo "  $0 python 3.13                        # Generate python/3.13/{Containerfile,app.conf}"
 }
 
 generate_cuda() {
@@ -323,12 +410,44 @@ main() {
 
     local type="$1"
     local version="$2"
+    shift 2
+
+    # Parse optional flags
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --torch-backend)
+                if [[ $# -lt 2 ]]; then
+                    log_error "--torch-backend requires a value (e.g., cu128, cu130)"
+                    exit 1
+                fi
+                TORCH_BACKEND="$2"
+                if [[ ! "${TORCH_BACKEND}" =~ ^cu[0-9]+$ ]]; then
+                    log_error "Invalid torch backend format: '${TORCH_BACKEND}'"
+                    log_error "Expected format: cu<digits> (e.g., cu128, cu130)"
+                    exit 1
+                fi
+                shift 2
+                ;;
+            --skip-pytorch-check)
+                SKIP_PYTORCH_CHECK=true
+                shift
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                print_usage
+                exit 1
+                ;;
+        esac
+    done
 
     case "${type}" in
         cuda)
             generate_cuda "${version}"
             ;;
         python)
+            if [[ -n "${TORCH_BACKEND}" || "${SKIP_PYTORCH_CHECK}" == "true" ]]; then
+                log_warn "--torch-backend and --skip-pytorch-check are ignored for python images"
+            fi
             generate_python "${version}"
             ;;
         *)

--- a/tests/test_cuda_image.py
+++ b/tests/test_cuda_image.py
@@ -5,6 +5,7 @@ and labels. All tests run without GPU hardware.
 """
 
 import os
+import re
 
 import pytest
 
@@ -147,6 +148,29 @@ def test_libcudss_present(cuda_container):
 def test_cuda_version_label(cuda_container):
     """Verify CUDA version label is present."""
     assert "com.nvidia.cuda.version" in cuda_container.get_labels()
+
+
+def test_uv_torch_backend(cuda_container):
+    """Verify torch-backend is configured in uv.toml for CUDA wheel selection.
+
+    Uses a specific backend (e.g. cu128, cu130) rather than "auto" because
+    auto detects GPU drivers at runtime, which are absent during container builds.
+    Configured via uv.toml (not ENV) to avoid uv erroring on empty values.
+    """
+    result = cuda_container.run("cat /etc/uv/uv.toml")
+    assert result.returncode == 0, "Failed to read /etc/uv/uv.toml"
+    assert "torch-backend" in result.stdout, (
+        "torch-backend should be configured in /etc/uv/uv.toml for CUDA images"
+    )
+    # Verify it's set to a valid CUDA backend (cuNNN format), not "auto" or "cpu"
+    match = re.search(r'torch-backend\s*=\s*"(cu\d+)"', result.stdout)
+    assert match, f'Expected torch-backend = "cuNNN" in uv.toml, got:\n{result.stdout}'
+    # If UV_TORCH_BACKEND is set in the test environment, verify the exact value matches
+    expected_backend = os.environ.get("UV_TORCH_BACKEND")
+    if expected_backend is not None:
+        assert match.group(1) == expected_backend, (
+            f'Expected torch-backend = "{expected_backend}", got "{match.group(1)}"'
+        )
 
 
 def test_accelerator_label_cuda(cuda_container):


### PR DESCRIPTION
Set UV_TORCH_BACKEND to specific CUDA backends (cu128, cu130) so that `uv pip install torch` selects the correct CUDA wheels during container builds. Using "auto" was not viable because it detects GPU drivers at runtime, which are absent during builds, causing a fallback to CPU wheels.

Closes #120
Ref #2

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable PyTorch CUDA backend via UV_TORCH_BACKEND; uv configuration records torch-backend when set.

* **Tests**
  * Added a test to verify uv's torch-backend entry exists and is well-formed in CUDA images; optionally enforces the exact backend when set.

* **Chores**
  * Updated docs and build examples to expose the new build-arg and guidance.
  * Build tooling now supports optional online validation of PyTorch wheel indices and new CLI flags to control it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->