### PR TITLE
Enable Renovate Tekton manager for automated task bundle updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,18 @@
   ],
   "labels": ["dependencies"],
   "branchPrefix": "konflux/mintmaker/",
+  "tekton": {
+    "enabled": true,
+    "includePaths": [".tekton/**"],
+    "packageRules": [
+      {
+        "matchUpdateTypes": ["digest"],
+        "matchBaseBranches": [],
+        "platformAutomerge": true,
+        "automerge": true
+      }
+    ]
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Enables Renovate's built-in Tekton manager to automatically update Konflux task bundle digests.

closes #149 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation to add Tekton support and scope it to Tekton-related files.
  * Enabled automated merging for digest-type dependency updates (including platform automerge).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->