### PR TITLE
fix: broken links in CUDA version issue template

### DIFF
--- a/.github/workflows/check-cuda-versions.yml
+++ b/.github/workflows/check-cuda-versions.yml
@@ -193,8 +193,8 @@ jobs:
 
           ## References
 
-          - [Adding New CUDA Version Guide](AGENTS.md#adding-a-new-cuda-version)
-          - [NVIDIA CUDA Dockerfiles](https://gitlab.com/nvidia/container-images/cuda/-/tree/master/dist/VERSION_PLACEHOLDER)
+          - [Adding New CUDA Version Guide](https://github.com/opendatahub-io/base-containers/blob/main/AGENTS.md#adding-a-new-cuda-version)
+          - [NVIDIA CUDA VERSION_PLACEHOLDER Dockerfiles](https://gitlab.com/nvidia/container-images/cuda/-/tree/master/dist)
 
           ---
           *This issue was automatically created by the check-cuda-versions workflow.*


### PR DESCRIPTION
- Use absolute URL for AGENTS.md guide
- Link to dist/ directory instead of non-existent version path

Fixes #144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated reference links in GitHub workflow configuration for automated issue templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->