### PR TITLE
fix(ci): add pagination to check-cuda-versions GitLab API calls

### DIFF
--- a/.github/workflows/check-cuda-versions.yml
+++ b/.github/workflows/check-cuda-versions.yml
@@ -76,15 +76,53 @@ jobs:
 
           API_BASE="https://gitlab.com/api/v4/projects"
 
+          # Fetch all pages from a GitLab repository tree endpoint
+          # Args: $1 = project identifier (path or ID)
+          fetch_all_pages() {
+            local project_id="$1"
+            local url="${API_BASE}/${project_id}/repository/tree?path=dist&per_page=100"
+            local all_items="[]"
+            local max_pages=10  # Safety limit: 10 pages × 100 items = 1000 max
+            local page
+
+            for ((page = 1; page <= max_pages; page++)); do
+              local response
+              response=$(curl -sf --retry 3 --retry-delay 5 "${url}&page=${page}" || echo "[]")
+
+              # Break if empty response or empty array
+              if [[ -z "${response}" || "${response}" == "[]" ]]; then
+                break
+              fi
+
+              local count
+              count=$(echo "${response}" | jq 'length')
+              if [[ "${count}" -eq 0 ]]; then
+                break
+              fi
+
+              # Merge into accumulated results
+              all_items=$(echo "${all_items}" "${response}" | jq -s 'add')
+
+              # If we got fewer than per_page items, this is the last page
+              if [[ "${count}" -lt 100 ]]; then
+                break
+              fi
+            done
+
+            if [[ ${page} -gt ${max_pages} ]]; then
+              echo "::warning::Pagination safety limit reached (${max_pages} pages)" >&2
+            fi
+
+            echo "${all_items}"
+          }
+
           # Try URL-encoded path first (more stable)
-          RESPONSE=$(curl -sf --retry 3 --retry-delay 5 \
-            "${API_BASE}/${NVIDIA_PROJECT_PATH}/repository/tree?path=dist&per_page=100" || echo "")
+          RESPONSE=$(fetch_all_pages "${NVIDIA_PROJECT_PATH}")
 
           # Fallback to numeric ID if path-based lookup fails
           if [[ -z "${RESPONSE}" || "${RESPONSE}" == "[]" ]]; then
             echo "Path-based lookup failed, trying numeric project ID..."
-            RESPONSE=$(curl -sf --retry 3 --retry-delay 5 \
-              "${API_BASE}/${NVIDIA_PROJECT_ID}/repository/tree?path=dist&per_page=100" || echo "[]")
+            RESPONSE=$(fetch_all_pages "${NVIDIA_PROJECT_ID}")
           fi
 
           if [[ -z "${RESPONSE}" || "${RESPONSE}" == "[]" ]]; then


### PR DESCRIPTION

Add pagination support to the check-cuda-versions workflow's GitLab API calls
Extract API fetching into a fetch_all_pages() function that loops through pages until exhausted
Include safety limit (10 pages / 1000 items) with ::warning:: annotation if reached


Fixes https://github.com/opendatahub-io/base-containers/issues/28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the CI workflow that checks CUDA versions: it now reliably retrieves all paginated results, combines them into a single response, enforces a safe page limit, and emits warnings on excessive pagination to avoid missed or partial lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->