### PR TITLE
Add ROCm 6.4.3 base image support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
             local type="$1"
             find "${type}" -maxdepth 1 -type d -name '[0-9]*.[0-9]*' \
               | sed "s|${type}/||" \
+              | grep -E '^[0-9]+\.[0-9]+$' \
               | sort -V
           }
 
@@ -245,16 +246,25 @@ jobs:
 
       - name: Get image tag from config
         id: config
+        env:
+          VERSION: ${{ matrix.version }}
         run: |
-          TAG=$(grep '^IMAGE_TAG=' python/${{ matrix.version }}/app.conf | cut -d'=' -f2)
-          if [ -z "$TAG" ]; then
-            echo "::error::IMAGE_TAG not found in python/${{ matrix.version }}/app.conf"
+          # Validate version format to prevent injection
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: ${VERSION}"
             exit 1
           fi
-          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          TAG=$(grep '^IMAGE_TAG=' "python/${VERSION}/app.conf" | cut -d'=' -f2)
+          if [ -z "$TAG" ]; then
+            echo "::error::IMAGE_TAG not found in python/${VERSION}/app.conf"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Build Python ${{ matrix.version }} image
-        run: ./scripts/build.sh python-${{ matrix.version }}
+        env:
+          VERSION: ${{ matrix.version }}
+        run: ./scripts/build.sh "python-${VERSION}"
 
       - name: Run Python image tests
         env:
@@ -328,16 +338,25 @@ jobs:
 
       - name: Get image tag from config
         id: config
+        env:
+          VERSION: ${{ matrix.version }}
         run: |
-          TAG=$(grep '^IMAGE_TAG=' cuda/${{ matrix.version }}/app.conf | cut -d'=' -f2)
-          if [ -z "$TAG" ]; then
-            echo "::error::IMAGE_TAG not found in cuda/${{ matrix.version }}/app.conf"
+          # Validate version format to prevent injection
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: ${VERSION}"
             exit 1
           fi
-          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          TAG=$(grep '^IMAGE_TAG=' "cuda/${VERSION}/app.conf" | cut -d'=' -f2)
+          if [ -z "$TAG" ]; then
+            echo "::error::IMAGE_TAG not found in cuda/${VERSION}/app.conf"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Build CUDA ${{ matrix.version }} image
-        run: ./scripts/build.sh cuda-${{ matrix.version }}
+        env:
+          VERSION: ${{ matrix.version }}
+        run: ./scripts/build.sh "cuda-${VERSION}"
 
       - name: Run CUDA image tests
         env:
@@ -411,16 +430,25 @@ jobs:
 
       - name: Get image tag from config
         id: config
+        env:
+          VERSION: ${{ matrix.version }}
         run: |
-          TAG=$(grep '^IMAGE_TAG=' rocm/${{ matrix.version }}/app.conf | cut -d'=' -f2)
-          if [ -z "$TAG" ]; then
-            echo "::error::IMAGE_TAG not found in rocm/${{ matrix.version }}/app.conf"
+          # Validate version format to prevent injection
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: ${VERSION}"
             exit 1
           fi
-          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          TAG=$(grep '^IMAGE_TAG=' "rocm/${VERSION}/app.conf" | cut -d'=' -f2)
+          if [ -z "$TAG" ]; then
+            echo "::error::IMAGE_TAG not found in rocm/${VERSION}/app.conf"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Build ROCm ${{ matrix.version }} image
-        run: ./scripts/build.sh rocm-${{ matrix.version }}
+        env:
+          VERSION: ${{ matrix.version }}
+        run: ./scripts/build.sh "rocm-${VERSION}"
 
       - name: Run ROCm image tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       any-cuda: ${{ steps.filter.outputs['any-cuda'] }}
+      any-rocm: ${{ steps.filter.outputs['any-rocm'] }}
       any-python: ${{ steps.filter.outputs['any-python'] }}
       cuda-versions: ${{ steps.cuda-versions.outputs.versions }}
+      rocm-versions: ${{ steps.rocm-versions.outputs.versions }}
       python-versions: ${{ steps.python-versions.outputs.versions }}
     steps:
       - uses: actions/checkout@v6
@@ -41,6 +43,17 @@ jobs:
               - 'tests/conftest.py'
               - 'tests/test_cuda_image.py'
               - 'tests/__init__.py'
+            any-rocm:
+              - 'rocm/**/Containerfile'
+              - 'rocm/**/app.conf'
+              - 'scripts/fix-permissions'
+              - 'scripts/build.sh'
+              - 'requirements-build.txt'
+              - '.dockerignore'
+              - 'tests/test_common.py'
+              - 'tests/conftest.py'
+              - 'tests/test_rocm_image.py'
+              - 'tests/__init__.py'
             any-python:
               - 'python/**/Containerfile'
               - 'python/**/app.conf'
@@ -50,7 +63,7 @@ jobs:
               - '.dockerignore'
               - 'tests/test_common.py'
               - 'tests/conftest.py'
-              - 'tests/test_python_image.py'  
+              - 'tests/test_python_image.py'
               - 'tests/__init__.py'
               
       - name: Build CUDA version matrix
@@ -77,6 +90,32 @@ jobs:
               | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?",":""), $0} END{print "]"}')
           fi
           
+          echo "versions=${VERSIONS}" >> "$GITHUB_OUTPUT"
+
+      - name: Build ROCm version matrix
+        id: rocm-versions
+        if: steps.filter.outputs.any-rocm == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.filter.outputs.any-rocm_files }}
+        run: |
+          # Check if common files changed (affects all versions)
+          if echo "$CHANGED_FILES" | grep -qE 'requirements-build\.txt|scripts/fix-permissions|scripts/build\.sh|\.dockerignore|tests/'; then
+            echo "Common files changed - including all ROCm versions"
+            # Get all available ROCm versions from directory structure
+            VERSIONS=$(find rocm -maxdepth 1 -type d -name '[0-9]*.[0-9]*' \
+              | sed 's|rocm/||' \
+              | sort -V \
+              | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?",":""), $0} END{print "]"}')
+          else
+            # Extract only specific versions from changed rocm/<version>/{Containerfile,app.conf} paths
+            VERSIONS=$(echo "$CHANGED_FILES" \
+              | tr -d '[]" ' \
+              | tr ',' '\n' \
+              | awk -F/ '$1=="rocm" && $2 ~ /^[0-9]+\.[0-9]+$/ && ($3=="Containerfile" || $3=="app.conf") {print $2}' \
+              | sort -uV \
+              | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?",":""), $0} END{print "]"}')
+          fi
+
           echo "versions=${VERSIONS}" >> "$GITHUB_OUTPUT"
 
       - name: Build Python version matrix
@@ -315,6 +354,89 @@ jobs:
           CUDA_VERSION: ${{ matrix.version }}
         run: pytest tests/test_cuda_image.py tests/test_common.py -v
 
+  test-rocm-image:
+    name: Test ROCm ${{ matrix.version }} Image
+    runs-on: ubuntu-latest
+    needs: [lint, type-check, changes, lint-containerfiles]
+    # Run when ROCm-related files change AND lint-containerfiles passed/skipped
+    if: |
+      always() &&
+      needs.changes.outputs['any-rocm'] == 'true' &&
+      needs.changes.outputs.rocm-versions != '' &&
+      needs.changes.outputs.rocm-versions != '[]' &&
+      needs.lint.result == 'success' &&
+      needs.type-check.result == 'success' &&
+      (needs.lint-containerfiles.result == 'success' || needs.lint-containerfiles.result == 'skipped')
+    strategy:
+      matrix:
+        version: ${{ fromJSON(needs.changes.outputs.rocm-versions || '[]') }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6
+
+      # Free disk space for ROCm build (large image)
+      # https://github.com/jlumbroso/free-disk-space
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false  # Keep for actions/setup-python
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      # Additional cleanup (complements jlumbroso action)
+      # Referenced from: https://github.com/opendatahub-io/notebooks/.github/actions/free-up-disk-space
+      - name: Additional disk cleanup
+        run: |
+          # Run cleanup in parallel for speed
+          sudo rm -rf /usr/local/.ghcup &
+          sudo rm -rf /usr/local/share/boost &
+          sudo rm -rf /usr/local/lib/node_modules &
+          sudo rm -rf /opt/hostedtoolcache/CodeQL &
+          sudo rm -rf /opt/hostedtoolcache/go &
+          sudo rm -rf /opt/hostedtoolcache/Ruby &
+          sudo rm -rf /opt/hostedtoolcache/PyPy &
+          wait
+
+          # Show available space
+          echo "=== Available disk space ==="
+          df -h /
+          AVAILABLE=$(df -BG / | tail -1 | awk '{print $4}' | tr -d 'G')
+          echo "Available: ${AVAILABLE}GB"
+          if [ "$AVAILABLE" -lt 30 ]; then
+            echo "::warning::Less than 30GB available for ROCm build"
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: pip install -e ".[test]"
+
+      - name: Get image tag from config
+        id: config
+        run: |
+          TAG=$(grep '^IMAGE_TAG=' rocm/${{ matrix.version }}/app.conf | cut -d'=' -f2)
+          if [ -z "$TAG" ]; then
+            echo "::error::IMAGE_TAG not found in rocm/${{ matrix.version }}/app.conf"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+
+      - name: Build ROCm ${{ matrix.version }} image
+        run: ./scripts/build.sh rocm-${{ matrix.version }}
+
+      - name: Run ROCm image tests
+        env:
+          ROCM_IMAGE: ${{ env.IMAGE_REGISTRY }}/odh-midstream-rocm-base:${{ steps.config.outputs.tag }}
+          ROCM_VERSION: ${{ matrix.version }}
+        run: pytest tests/test_rocm_image.py tests/test_common.py -v
+
   # Aggregator job for branch protection - use this as the required status check
   # This ensures all jobs (including conditional ones) must pass before merging
   ci-status:
@@ -327,6 +449,7 @@ jobs:
       - lint-containerfiles
       - test-python-image
       - test-cuda-image
+      - test-rocm-image
     steps:
       - name: Check CI status
         run: |
@@ -335,9 +458,10 @@ jobs:
           echo "lint-containerfiles: ${{ needs.lint-containerfiles.result }}"
           echo "test-python-image: ${{ needs.test-python-image.result }}"
           echo "test-cuda-image: ${{ needs.test-cuda-image.result }}"
+          echo "test-rocm-image: ${{ needs.test-rocm-image.result }}"
 
           # Fail if any required job failed or was cancelled
-          # Note: 'skipped' is OK for conditional jobs (lint-containerfiles, test-cuda-image)
+          # Note: 'skipped' is OK for conditional jobs (lint-containerfiles, test-cuda-image, test-rocm-image)
           if [[ "${{ needs.lint.result }}" == "failure" || \
                 "${{ needs.lint.result }}" == "cancelled" || \
                 "${{ needs.type-check.result }}" == "failure" || \
@@ -347,7 +471,9 @@ jobs:
                 "${{ needs.test-python-image.result }}" == "failure" || \
                 "${{ needs.test-python-image.result }}" == "cancelled" || \
                 "${{ needs.test-cuda-image.result }}" == "failure" || \
-                "${{ needs.test-cuda-image.result }}" == "cancelled" ]]; then
+                "${{ needs.test-cuda-image.result }}" == "cancelled" || \
+                "${{ needs.test-rocm-image.result }}" == "failure" || \
+                "${{ needs.test-rocm-image.result }}" == "cancelled" ]]; then
             echo "::error::One or more CI jobs failed or were cancelled"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
       any-cuda: ${{ steps.filter.outputs['any-cuda'] }}
       any-rocm: ${{ steps.filter.outputs['any-rocm'] }}
       any-python: ${{ steps.filter.outputs['any-python'] }}
-      cuda-versions: ${{ steps.cuda-versions.outputs.versions }}
-      rocm-versions: ${{ steps.rocm-versions.outputs.versions }}
-      python-versions: ${{ steps.python-versions.outputs.versions }}
+      cuda-versions: ${{ steps.build-matrices.outputs.cuda-versions }}
+      rocm-versions: ${{ steps.build-matrices.outputs.rocm-versions }}
+      python-versions: ${{ steps.build-matrices.outputs.python-versions }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -66,83 +66,74 @@ jobs:
               - 'tests/test_python_image.py'
               - 'tests/__init__.py'
               
-      - name: Build CUDA version matrix
-        id: cuda-versions
-        if: steps.filter.outputs.any-cuda == 'true'
+      - name: Build version matrices
+        id: build-matrices
         env:
-          CHANGED_FILES: ${{ steps.filter.outputs.any-cuda_files }}
+          FILTER_CUDA: ${{ steps.filter.outputs.any-cuda }}
+          FILES_CUDA: ${{ steps.filter.outputs.any-cuda_files }}
+          FILTER_ROCM: ${{ steps.filter.outputs.any-rocm }}
+          FILES_ROCM: ${{ steps.filter.outputs.any-rocm_files }}
+          FILTER_PYTHON: ${{ steps.filter.outputs.any-python }}
+          FILES_PYTHON: ${{ steps.filter.outputs.any-python_files }}
         run: |
-          # Check if common files changed (affects all versions)
-          if echo "$CHANGED_FILES" | grep -qE 'requirements-build\.txt|scripts/fix-permissions|scripts/build\.sh|\.dockerignore|tests/'; then
-            echo "Common files changed - including all CUDA versions"
-            # Get all available CUDA versions from directory structure
-            VERSIONS=$(find cuda -maxdepth 1 -type d -name '[0-9]*.[0-9]*' \
-              | sed 's|cuda/||' \
-              | sort -V \
-              | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?",":""), $0} END{print "]"}')
-          else
-            # Extract only specific versions from changed cuda/<version>/{Containerfile,app.conf} paths
-            VERSIONS=$(echo "$CHANGED_FILES" \
+          # Converts a newline-separated list of versions into a JSON array
+          # e.g., "12.8\n12.9" -> '["12.8","12.9"]'
+          to_json_array() {
+            sort -uV | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?",":""), $0} END{print "]"}'
+          }
+
+          # Lists all version directories for a given image type
+          # e.g., all_versions "cuda" -> "12.8\n12.9\n13.0"
+          all_versions() {
+            local type="$1"
+            find "${type}" -maxdepth 1 -type d -name '[0-9]*.[0-9]*' \
+              | sed "s|${type}/||" \
+              | sort -V
+          }
+
+          # Extracts version numbers from changed file paths
+          # e.g., changed_versions "cuda" '["cuda/12.8/Containerfile"]' -> "12.8"
+          changed_versions() {
+            local type="$1"
+            local files="$2"
+            echo "$files" \
               | tr -d '[]" ' \
               | tr ',' '\n' \
-              | awk -F/ '$1=="cuda" && $2 ~ /^[0-9]+\.[0-9]+$/ && ($3=="Containerfile" || $3=="app.conf") {print $2}' \
-              | sort -uV \
-              | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?",":""), $0} END{print "]"}')
-          fi
-          
-          echo "versions=${VERSIONS}" >> "$GITHUB_OUTPUT"
+              | awk -F/ -v t="${type}" \
+                  '$1==t && $2 ~ /^[0-9]+\.[0-9]+$/ && ($3=="Containerfile" || $3=="app.conf") {print $2}'
+          }
 
-      - name: Build ROCm version matrix
-        id: rocm-versions
-        if: steps.filter.outputs.any-rocm == 'true'
-        env:
-          CHANGED_FILES: ${{ steps.filter.outputs.any-rocm_files }}
-        run: |
-          # Check if common files changed (affects all versions)
-          if echo "$CHANGED_FILES" | grep -qE 'requirements-build\.txt|scripts/fix-permissions|scripts/build\.sh|\.dockerignore|tests/'; then
-            echo "Common files changed - including all ROCm versions"
-            # Get all available ROCm versions from directory structure
-            VERSIONS=$(find rocm -maxdepth 1 -type d -name '[0-9]*.[0-9]*' \
-              | sed 's|rocm/||' \
-              | sort -V \
-              | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?",":""), $0} END{print "]"}')
-          else
-            # Extract only specific versions from changed rocm/<version>/{Containerfile,app.conf} paths
-            VERSIONS=$(echo "$CHANGED_FILES" \
-              | tr -d '[]" ' \
-              | tr ',' '\n' \
-              | awk -F/ '$1=="rocm" && $2 ~ /^[0-9]+\.[0-9]+$/ && ($3=="Containerfile" || $3=="app.conf") {print $2}' \
-              | sort -uV \
-              | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?",":""), $0} END{print "]"}')
-          fi
+          # Files shared across all versions of an image type. When any of
+          # these change, every version of that type needs to be rebuilt.
+          is_common_file() {
+            local type="$1"
+            local files="$2"
+            echo "$files" | grep -qE \
+              "requirements-build\.txt|scripts/fix-permissions|scripts/build\.sh|\.dockerignore|tests/"
+          }
 
-          echo "versions=${VERSIONS}" >> "$GITHUB_OUTPUT"
+          # Build matrix for each image type
+          for type in cuda rocm python; do
+            # Read filter outputs from environment (e.g., FILTER_CUDA, FILES_CUDA)
+            enabled_var="FILTER_${type^^}"
+            files_var="FILES_${type^^}"
+            enabled="${!enabled_var}"
+            files="${!files_var}"
 
-      - name: Build Python version matrix
-        id: python-versions
-        if: steps.filter.outputs.any-python == 'true'
-        env:
-          CHANGED_FILES: ${{ steps.filter.outputs.any-python_files }}
-        run: |
-          # Check if common files changed (affects all versions)
-          if echo "$CHANGED_FILES" | grep -qE 'requirements-build\.txt|scripts/fix-permissions|scripts/build\.sh|\.dockerignore|tests/'; then
-            echo "Common files changed - including all Python versions"
-            # Get all available Python versions from directory structure
-            VERSIONS=$(find python -maxdepth 1 -type d -name '[0-9]*.[0-9]*' \
-              | sed 's|python/||' \
-              | sort -V \
-              | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?",":""), $0} END{print "]"}')
-          else
-            # Extract only specific versions from changed python/<version>/{Containerfile,app.conf} paths
-            VERSIONS=$(echo "$CHANGED_FILES" \
-              | tr -d '[]" ' \
-              | tr ',' '\n' \
-              | awk -F/ '$1=="python" && $2 ~ /^[0-9]+\.[0-9]+$/ && ($3=="Containerfile" || $3=="app.conf") {print $2}' \
-              | sort -uV \
-              | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1?",":""), $0} END{print "]"}')
-          fi
-          
-          echo "versions=${VERSIONS}" >> "$GITHUB_OUTPUT"
+            if [[ "${enabled}" != "true" ]]; then
+              echo "${type}-versions=[]" >> "$GITHUB_OUTPUT"
+              continue
+            fi
+
+            if is_common_file "${type}" "${files}"; then
+              echo "Common files changed - including all ${type} versions"
+              VERSIONS=$(all_versions "${type}" | to_json_array)
+            else
+              VERSIONS=$(changed_versions "${type}" "${files}" | to_json_array)
+            fi
+
+            echo "${type}-versions=${VERSIONS}" >> "$GITHUB_OUTPUT"
+          done
 
   lint:
     name: Lint (ruff)

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ build/
 dist/
 *.log
 
+# AI agents
+.claude

--- a/.tekton/odh-midstream-rocm-base-6-4-pull-request.yaml
+++ b/.tekton/odh-midstream-rocm-base-6-4-pull-request.yaml
@@ -50,11 +50,11 @@ spec:
         - name: app-check
           computeResources:
             requests:
-              memory: 8Gi
-              cpu: '2'
+              memory: 16Gi
+              cpu: '8'
             limits:
-              memory: 12Gi
-              cpu: '4'
+              memory: 20Gi
+              cpu: '8'
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-midstream-rocm-base-6-4
   workspaces:

--- a/.tekton/odh-midstream-rocm-base-6-4-pull-request.yaml
+++ b/.tekton/odh-midstream-rocm-base-6-4-pull-request.yaml
@@ -1,0 +1,64 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/base-containers?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" && target_branch == "main" && (
+        'rocm/6.4/**'.pathChanged() ||
+        'requirements-build.txt'.pathChanged() ||
+        'scripts/fix-permissions'.pathChanged() ||
+        '.dockerignore'.pathChanged() ||
+        '.tekton/odh-midstream-rocm-base-6-4-pull-request.yaml'.pathChanged()
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: odh-base-containers
+    appstudio.openshift.io/component: odh-midstream-rocm-base-6-4
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-midstream-rocm-base-6-4-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  timeouts:
+    pipeline: "2h0m0s"
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-midstream-rocm-base-6-4:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: rocm/6.4/Containerfile
+  - name: build-args-file
+    value: rocm/6.4/app.conf
+  pipelineRef:
+    name: odh-base-containers-pull-request
+  taskRunSpecs:
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      stepSpecs:
+        - name: app-check
+          computeResources:
+            requests:
+              memory: 8Gi
+              cpu: '2'
+            limits:
+              memory: 12Gi
+              cpu: '4'
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-midstream-rocm-base-6-4
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/odh-midstream-rocm-base-6-4-push.yaml
+++ b/.tekton/odh-midstream-rocm-base-6-4-push.yaml
@@ -1,0 +1,61 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/base-containers?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "main" && (
+        'rocm/6.4/**'.pathChanged() ||
+        'requirements-build.txt'.pathChanged() ||
+        'scripts/fix-permissions'.pathChanged() ||
+        '.dockerignore'.pathChanged() ||
+        '.tekton/odh-midstream-rocm-base-6-4-push.yaml'.pathChanged()
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: odh-base-containers
+    appstudio.openshift.io/component: odh-midstream-rocm-base-6-4
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-midstream-rocm-base-6-4-on-push
+  namespace: open-data-hub-tenant
+spec:
+  timeouts:
+    pipeline: "2h0m0s"
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-midstream-rocm-base-6-4:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: rocm/6.4/Containerfile
+  - name: build-args-file
+    value: rocm/6.4/app.conf
+  pipelineRef:
+    name: odh-base-containers-push
+  taskRunSpecs:
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      stepSpecs:
+        - name: app-check
+          computeResources:
+            requests:
+              memory: 8Gi
+              cpu: '2'
+            limits:
+              memory: 12Gi
+              cpu: '4'
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-midstream-rocm-base-6-4
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/odh-midstream-rocm-base-6-4-push.yaml
+++ b/.tekton/odh-midstream-rocm-base-6-4-push.yaml
@@ -47,11 +47,11 @@ spec:
         - name: app-check
           computeResources:
             requests:
-              memory: 8Gi
-              cpu: '2'
+              memory: 16Gi
+              cpu: '8'
             limits:
-              memory: 12Gi
-              cpu: '4'
+              memory: 20Gi
+              cpu: '8'
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-midstream-rocm-base-6-4
   workspaces:

--- a/Containerfile.rocm.template
+++ b/Containerfile.rocm.template
@@ -1,0 +1,267 @@
+# ODH ROCm Base Image (CentOS Stream 9)
+# ROCm Version: ${ROCM_MAJOR_MINOR_DOT}
+# Generated from Containerfile.rocm.template - edit template, not this file
+#
+# CentOS Stream 9 required: ROCm packages need CentOS Stream 9 / RHEL 9 repos
+# Usage: ./scripts/build.sh rocm-${ROCM_MAJOR_MINOR_DOT}
+# Build args: rocm/${ROCM_MAJOR_MINOR_DOT}/app.conf
+
+ARG BASE_IMAGE
+ARG ROCM_MAJOR
+ARG ROCM_MAJOR_MINOR
+ARG ROCM_MAJOR_MINOR_DOT
+ARG ROCM_VERSION
+
+# Build metadata for OCI labels
+ARG BUILD_DATE
+ARG VCS_REF=unknown
+ARG VERSION=0.0.1
+
+# -----------------------------------------------------------------------------
+# Base stage (x86_64 only - ROCm does not support ARM64)
+# -----------------------------------------------------------------------------
+FROM ${BASE_IMAGE} AS rocm-base
+
+ARG ROCM_MAJOR
+ARG ROCM_MAJOR_MINOR
+ARG ROCM_MAJOR_MINOR_DOT
+ARG ROCM_VERSION
+
+USER 0
+WORKDIR /opt/app-root/bin
+
+# -----------------------------------------------------------------------------
+# ROCm Version Environment
+# Source: https://repo.radeon.com/rocm/
+# -----------------------------------------------------------------------------
+ENV ROCM_VERSION=${ROCM_VERSION}
+ENV ROCM_HOME=/opt/rocm
+
+# -----------------------------------------------------------------------------
+# ROCm Repository Setup
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf install -y --setopt=keepcache=1 --allowerasing curl ca-certificates
+
+# Download and verify GPG key before creating repo
+RUN ROCM_GPGKEY_SUM=2de99e2354646a90d9903e2a669fc4e36b02c1bbff7075c481e12d7edab2c88b && \
+    curl -fsSL "https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/pki/rpm-gpg/RPM-GPG-KEY-ROCM && \
+    echo "$ROCM_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-ROCM" | sha256sum -c --strict -
+
+# Create repo config pointing to locally verified key
+# priority=150: prefer base OS packages over AMD's (e.g., llvm*-libs)
+# to avoid conflicts with packages that depend on RHEL's LLVM
+RUN { echo "[rocm-el9]"; \
+      echo "name=ROCm ${ROCM_VERSION} for EL9"; \
+      echo "baseurl=https://repo.radeon.com/rocm/el9/${ROCM_VERSION}/main/"; \
+      echo "enabled=1"; \
+      echo "priority=150"; \
+      echo "gpgcheck=1"; \
+      echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ROCM"; \
+    } > /etc/yum.repos.d/rocm.repo
+
+# -----------------------------------------------------------------------------
+# ROCm Base Packages
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf upgrade -y --setopt=keepcache=1 && \
+    dnf install -y --setopt=keepcache=1 \
+        rocm-core \
+        hip-runtime-amd
+
+# Configure ROCm library paths
+ENV PATH=/opt/rocm/bin:/opt/rocm/hip/bin:${PATH}
+ENV LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib64
+
+# -----------------------------------------------------------------------------
+# ROCm Runtime Libraries
+# Source: https://repo.radeon.com/rocm/el9/
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf install -y --setopt=keepcache=1 \
+        rocblas \
+        rocfft \
+        rocsolver \
+        rocsparse \
+        rccl \
+        miopen-hip
+
+# -----------------------------------------------------------------------------
+# Development Tools
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf install -y --setopt=keepcache=1 make findutils
+
+# -----------------------------------------------------------------------------
+# ROCm Profiling Tools
+# Required by PyTorch profiler for GPU profiling on AMD hardware.
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf install -y --setopt=keepcache=1 rocprofiler
+
+# -----------------------------------------------------------------------------
+# ROCm HIP SDK (toolkit)
+# Provides hipcc compiler and development headers for building HIP code.
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf -y install --setopt=keepcache=1 rocm-hip-sdk
+
+# -----------------------------------------------------------------------------
+# ROCm Shared Library Configuration
+# Register ROCm libraries with the dynamic linker so they are discoverable
+# via ldconfig. ROCm binaries also have rpath set, but ld.so.conf.d ensures
+# consistent behavior for all consumers.
+# Ref: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/post-install.html#configure-rocm-shared-objects
+# -----------------------------------------------------------------------------
+RUN echo "${ROCM_HOME}/lib" > /etc/ld.so.conf.d/rocm.conf && \
+    ldconfig
+
+# -----------------------------------------------------------------------------
+# Environment (consistent with Python base image)
+# -----------------------------------------------------------------------------
+
+# Python settings - prevent bytecode files and enable unbuffered output
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    UV_SYSTEM_PYTHON=1 \
+    UV_NO_CACHE=1
+
+# -----------------------------------------------------------------------------
+# Package Index Configuration
+# -----------------------------------------------------------------------------
+# Configure pip and uv to use the specified package indexes.
+# Users can simply run: pip install <pkg> or uv pip install <pkg>
+# Override indexes at build time via --build-arg for downstream builds.
+
+ARG PIP_INDEX_URL=https://pypi.org/simple
+ARG PIP_EXTRA_INDEX_URL
+ARG UV_TORCH_BACKEND=
+
+# pip configuration (system-wide) - must be created before installing uv
+RUN mkdir -p /etc/pip && \
+    { echo "[global]"; \
+      echo "index-url = ${PIP_INDEX_URL}"; \
+      [ -n "${PIP_EXTRA_INDEX_URL}" ] && echo "extra-index-url = ${PIP_EXTRA_INDEX_URL}"; \
+      true; \
+    } > /etc/pip.conf
+
+# Install uv - fast Python package installer
+# https://github.com/astral-sh/uv
+# Version pinned in requirements-build.txt
+COPY --chmod=644 --chown=0:0 requirements-build.txt /tmp/requirements-build.txt
+RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
+    rm /tmp/requirements-build.txt
+
+# uv configuration (system-wide)
+# Note: PIP_EXTRA_INDEX_URL is intentionally omitted from uv.toml because
+# UV_TORCH_BACKEND is uv's native mechanism for PyTorch ROCm wheel resolution.
+# torch-backend is written to uv.toml (not ENV) to avoid uv erroring on empty values.
+# Downstream builds can disable by omitting UV_TORCH_BACKEND or rebuilding uv.toml.
+RUN mkdir -p /etc/uv && \
+    { echo "[pip]"; \
+      echo "index-url = \"${PIP_INDEX_URL}\""; \
+      [ -n "${UV_TORCH_BACKEND}" ] && echo "torch-backend = \"${UV_TORCH_BACKEND}\""; \
+      true; \
+    } > /etc/uv/uv.toml
+ENV UV_CONFIG_FILE=/etc/uv/uv.toml
+
+# Copy fix-permissions script from sclorg for OpenShift compatibility
+# Source: https://github.com/sclorg/container-common-scripts
+COPY --chmod=755 --chown=0:0 scripts/fix-permissions /usr/local/bin/fix-permissions
+
+# -----------------------------------------------------------------------------
+# Directory Setup (from notebooks + trustyai patterns)
+# -----------------------------------------------------------------------------
+
+# Create cache directories with proper permissions for OpenShift
+# fix-permissions ensures group 0 can read/write, enabling arbitrary UID
+RUN mkdir -p /opt/app-root/src/.cache && \
+    chown -R 1001:0 /opt/app-root && \
+    fix-permissions /opt/app-root -P
+
+# -----------------------------------------------------------------------------
+# Final Cleanup
+# -----------------------------------------------------------------------------
+RUN dnf clean all && \
+    rm -rf /var/cache/dnf /var/log/dnf* /var/log/hawkey*
+
+# -----------------------------------------------------------------------------
+# Labels
+# -----------------------------------------------------------------------------
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+ARG PYTHON_VERSION
+
+LABEL name="odh-midstream-rocm-base" \
+      version="${VERSION}" \
+      summary="ODH ROCm Base Image" \
+      description="CentOS Stream 9 with ROCm and Python for Open Data Hub workloads" \
+      io.k8s.display-name="ODH ROCm Base" \
+      io.k8s.description="CentOS Stream 9 with ROCm and Python for Open Data Hub workloads" \
+      io.openshift.tags="rocm,python,ai,ml,gpu,c9s" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.title="ODH ROCm Base Image" \
+      org.opencontainers.image.description="CentOS Stream 9 with ROCm and Python for Open Data Hub workloads" \
+      org.opencontainers.image.source="https://github.com/opendatahub-io/base-containers" \
+      org.opencontainers.image.vendor="Open Data Hub" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      com.amd.rocm.version="${ROCM_VERSION}" \
+      com.opendatahub.accelerator="rocm" \
+      com.opendatahub.python="${PYTHON_VERSION}"
+
+# -----------------------------------------------------------------------------
+# User Configuration (from notebooks pattern)
+# -----------------------------------------------------------------------------
+
+# Switch to non-root user
+# UID 1001 is standard for sclorg Python images and OpenShift SCC compatible
+USER 1001
+
+# Standard workdir for Python images
+WORKDIR /opt/app-root/src
+
+# -----------------------------------------------------------------------------
+# Health Check
+# -----------------------------------------------------------------------------
+# Child images can add a HEALTHCHECK - example pattern:
+# HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+#     CMD python -c "import myapp; myapp.health_check()" || exit 1
+
+# -----------------------------------------------------------------------------
+# Extending This Image
+# -----------------------------------------------------------------------------
+#
+# Example Dockerfile that extends this base:
+#
+#   FROM odh-midstream-rocm-base:${ROCM_MAJOR_MINOR_DOT}-py312
+#
+#   # Install dependencies (pip and uv are pre-configured with package indexes)
+#   COPY requirements.txt .
+#   RUN pip install -r requirements.txt
+#   # Or with uv (faster):
+#   # RUN uv pip install -r requirements.txt
+#
+#   # Copy application (preserve ownership for non-root user)
+#   COPY --chown=1001:0 . .
+#
+#   # Run application
+#   CMD ["python", "app.py"]
+#
+# -----------------------------------------------------------------------------
+#
+# Build for ODH (uses default package indexes):
+#   podman build -t myapp:odh .
+#
+# Build for RHOAI (override to use internal mirror):
+#   podman build -t myapp:rhoai \
+#     --build-arg PIP_INDEX_URL=https://aipcc.internal/simple \
+#     --build-arg PIP_EXTRA_INDEX_URL="" \
+#     --build-arg UV_TORCH_BACKEND= \
+#     .
+#
+# -----------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dev = [
     "tox>=4.0.0,<5.0.0",
 ]
 
+[tool.setuptools.packages.find]
+exclude = ["cuda*", "rocm*", "python*", "scripts*", "docs*"]
+
 [tool.ruff]
 target-version = "py312"
 line-length = 100

--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,8 @@
       "description": "Update BASE_IMAGE in app.conf files",
       "fileMatch": [
         "(^|/)python/[^/]+/app\\.conf$",
-        "(^|/)cuda/[^/]+/app\\.conf$"
+        "(^|/)cuda/[^/]+/app\\.conf$",
+        "(^|/)rocm/[^/]+/app\\.conf$"
       ],
       "matchStrings": [
         "BASE_IMAGE=(?<depName>[^:]+):(?<currentValue>[^@\\s]+)(@(?<currentDigest>sha256:[a-f0-9]+))?"

--- a/rocm/6.4/Containerfile
+++ b/rocm/6.4/Containerfile
@@ -1,0 +1,267 @@
+# ODH ROCm Base Image (CentOS Stream 9)
+# ROCm Version: ${ROCM_MAJOR_MINOR_DOT}
+# Generated from Containerfile.rocm.template - edit template, not this file
+#
+# CentOS Stream 9 required: ROCm packages need CentOS Stream 9 / RHEL 9 repos
+# Usage: ./scripts/build.sh rocm-${ROCM_MAJOR_MINOR_DOT}
+# Build args: rocm/${ROCM_MAJOR_MINOR_DOT}/app.conf
+
+ARG BASE_IMAGE
+ARG ROCM_MAJOR
+ARG ROCM_MAJOR_MINOR
+ARG ROCM_MAJOR_MINOR_DOT
+ARG ROCM_VERSION
+
+# Build metadata for OCI labels
+ARG BUILD_DATE
+ARG VCS_REF=unknown
+ARG VERSION=0.0.1
+
+# -----------------------------------------------------------------------------
+# Base stage (x86_64 only - ROCm does not support ARM64)
+# -----------------------------------------------------------------------------
+FROM ${BASE_IMAGE} AS rocm-base
+
+ARG ROCM_MAJOR
+ARG ROCM_MAJOR_MINOR
+ARG ROCM_MAJOR_MINOR_DOT
+ARG ROCM_VERSION
+
+USER 0
+WORKDIR /opt/app-root/bin
+
+# -----------------------------------------------------------------------------
+# ROCm Version Environment
+# Source: https://repo.radeon.com/rocm/
+# -----------------------------------------------------------------------------
+ENV ROCM_VERSION=${ROCM_VERSION}
+ENV ROCM_HOME=/opt/rocm
+
+# -----------------------------------------------------------------------------
+# ROCm Repository Setup
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf install -y --setopt=keepcache=1 --allowerasing curl ca-certificates
+
+# Download and verify GPG key before creating repo
+RUN ROCM_GPGKEY_SUM=2de99e2354646a90d9903e2a669fc4e36b02c1bbff7075c481e12d7edab2c88b && \
+    curl -fsSL "https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/pki/rpm-gpg/RPM-GPG-KEY-ROCM && \
+    echo "$ROCM_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-ROCM" | sha256sum -c --strict -
+
+# Create repo config pointing to locally verified key
+# priority=150: prefer base OS packages over AMD's (e.g., llvm*-libs)
+# to avoid conflicts with packages that depend on RHEL's LLVM
+RUN { echo "[rocm-el9]"; \
+      echo "name=ROCm ${ROCM_VERSION} for EL9"; \
+      echo "baseurl=https://repo.radeon.com/rocm/el9/${ROCM_VERSION}/main/"; \
+      echo "enabled=1"; \
+      echo "priority=150"; \
+      echo "gpgcheck=1"; \
+      echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ROCM"; \
+    } > /etc/yum.repos.d/rocm.repo
+
+# -----------------------------------------------------------------------------
+# ROCm Base Packages
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf upgrade -y --setopt=keepcache=1 && \
+    dnf install -y --setopt=keepcache=1 \
+        rocm-core \
+        hip-runtime-amd
+
+# Configure ROCm library paths
+ENV PATH=/opt/rocm/bin:/opt/rocm/hip/bin:${PATH}
+ENV LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib64
+
+# -----------------------------------------------------------------------------
+# ROCm Runtime Libraries
+# Source: https://repo.radeon.com/rocm/el9/
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf install -y --setopt=keepcache=1 \
+        rocblas \
+        rocfft \
+        rocsolver \
+        rocsparse \
+        rccl \
+        miopen-hip
+
+# -----------------------------------------------------------------------------
+# Development Tools
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf install -y --setopt=keepcache=1 make findutils
+
+# -----------------------------------------------------------------------------
+# ROCm Profiling Tools
+# Required by PyTorch profiler for GPU profiling on AMD hardware.
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf install -y --setopt=keepcache=1 rocprofiler
+
+# -----------------------------------------------------------------------------
+# ROCm HIP SDK (toolkit)
+# Provides hipcc compiler and development headers for building HIP code.
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf -y install --setopt=keepcache=1 rocm-hip-sdk
+
+# -----------------------------------------------------------------------------
+# ROCm Shared Library Configuration
+# Register ROCm libraries with the dynamic linker so they are discoverable
+# via ldconfig. ROCm binaries also have rpath set, but ld.so.conf.d ensures
+# consistent behavior for all consumers.
+# Ref: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/post-install.html#configure-rocm-shared-objects
+# -----------------------------------------------------------------------------
+RUN echo "${ROCM_HOME}/lib" > /etc/ld.so.conf.d/rocm.conf && \
+    ldconfig
+
+# -----------------------------------------------------------------------------
+# Environment (consistent with Python base image)
+# -----------------------------------------------------------------------------
+
+# Python settings - prevent bytecode files and enable unbuffered output
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    UV_SYSTEM_PYTHON=1 \
+    UV_NO_CACHE=1
+
+# -----------------------------------------------------------------------------
+# Package Index Configuration
+# -----------------------------------------------------------------------------
+# Configure pip and uv to use the specified package indexes.
+# Users can simply run: pip install <pkg> or uv pip install <pkg>
+# Override indexes at build time via --build-arg for downstream builds.
+
+ARG PIP_INDEX_URL=https://pypi.org/simple
+ARG PIP_EXTRA_INDEX_URL
+ARG UV_TORCH_BACKEND=
+
+# pip configuration (system-wide) - must be created before installing uv
+RUN mkdir -p /etc/pip && \
+    { echo "[global]"; \
+      echo "index-url = ${PIP_INDEX_URL}"; \
+      [ -n "${PIP_EXTRA_INDEX_URL}" ] && echo "extra-index-url = ${PIP_EXTRA_INDEX_URL}"; \
+      true; \
+    } > /etc/pip.conf
+
+# Install uv - fast Python package installer
+# https://github.com/astral-sh/uv
+# Version pinned in requirements-build.txt
+COPY --chmod=644 --chown=0:0 requirements-build.txt /tmp/requirements-build.txt
+RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
+    rm /tmp/requirements-build.txt
+
+# uv configuration (system-wide)
+# Note: PIP_EXTRA_INDEX_URL is intentionally omitted from uv.toml because
+# UV_TORCH_BACKEND is uv's native mechanism for PyTorch ROCm wheel resolution.
+# torch-backend is written to uv.toml (not ENV) to avoid uv erroring on empty values.
+# Downstream builds can disable by omitting UV_TORCH_BACKEND or rebuilding uv.toml.
+RUN mkdir -p /etc/uv && \
+    { echo "[pip]"; \
+      echo "index-url = \"${PIP_INDEX_URL}\""; \
+      [ -n "${UV_TORCH_BACKEND}" ] && echo "torch-backend = \"${UV_TORCH_BACKEND}\""; \
+      true; \
+    } > /etc/uv/uv.toml
+ENV UV_CONFIG_FILE=/etc/uv/uv.toml
+
+# Copy fix-permissions script from sclorg for OpenShift compatibility
+# Source: https://github.com/sclorg/container-common-scripts
+COPY --chmod=755 --chown=0:0 scripts/fix-permissions /usr/local/bin/fix-permissions
+
+# -----------------------------------------------------------------------------
+# Directory Setup (from notebooks + trustyai patterns)
+# -----------------------------------------------------------------------------
+
+# Create cache directories with proper permissions for OpenShift
+# fix-permissions ensures group 0 can read/write, enabling arbitrary UID
+RUN mkdir -p /opt/app-root/src/.cache && \
+    chown -R 1001:0 /opt/app-root && \
+    fix-permissions /opt/app-root -P
+
+# -----------------------------------------------------------------------------
+# Final Cleanup
+# -----------------------------------------------------------------------------
+RUN dnf clean all && \
+    rm -rf /var/cache/dnf /var/log/dnf* /var/log/hawkey*
+
+# -----------------------------------------------------------------------------
+# Labels
+# -----------------------------------------------------------------------------
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+ARG PYTHON_VERSION
+
+LABEL name="odh-midstream-rocm-base" \
+      version="${VERSION}" \
+      summary="ODH ROCm Base Image" \
+      description="CentOS Stream 9 with ROCm and Python for Open Data Hub workloads" \
+      io.k8s.display-name="ODH ROCm Base" \
+      io.k8s.description="CentOS Stream 9 with ROCm and Python for Open Data Hub workloads" \
+      io.openshift.tags="rocm,python,ai,ml,gpu,c9s" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.title="ODH ROCm Base Image" \
+      org.opencontainers.image.description="CentOS Stream 9 with ROCm and Python for Open Data Hub workloads" \
+      org.opencontainers.image.source="https://github.com/opendatahub-io/base-containers" \
+      org.opencontainers.image.vendor="Open Data Hub" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      com.amd.rocm.version="${ROCM_VERSION}" \
+      com.opendatahub.accelerator="rocm" \
+      com.opendatahub.python="${PYTHON_VERSION}"
+
+# -----------------------------------------------------------------------------
+# User Configuration (from notebooks pattern)
+# -----------------------------------------------------------------------------
+
+# Switch to non-root user
+# UID 1001 is standard for sclorg Python images and OpenShift SCC compatible
+USER 1001
+
+# Standard workdir for Python images
+WORKDIR /opt/app-root/src
+
+# -----------------------------------------------------------------------------
+# Health Check
+# -----------------------------------------------------------------------------
+# Child images can add a HEALTHCHECK - example pattern:
+# HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+#     CMD python -c "import myapp; myapp.health_check()" || exit 1
+
+# -----------------------------------------------------------------------------
+# Extending This Image
+# -----------------------------------------------------------------------------
+#
+# Example Dockerfile that extends this base:
+#
+#   FROM odh-midstream-rocm-base:${ROCM_MAJOR_MINOR_DOT}-py312
+#
+#   # Install dependencies (pip and uv are pre-configured with package indexes)
+#   COPY requirements.txt .
+#   RUN pip install -r requirements.txt
+#   # Or with uv (faster):
+#   # RUN uv pip install -r requirements.txt
+#
+#   # Copy application (preserve ownership for non-root user)
+#   COPY --chown=1001:0 . .
+#
+#   # Run application
+#   CMD ["python", "app.py"]
+#
+# -----------------------------------------------------------------------------
+#
+# Build for ODH (uses default package indexes):
+#   podman build -t myapp:odh .
+#
+# Build for RHOAI (override to use internal mirror):
+#   podman build -t myapp:rhoai \
+#     --build-arg PIP_INDEX_URL=https://aipcc.internal/simple \
+#     --build-arg PIP_EXTRA_INDEX_URL="" \
+#     --build-arg UV_TORCH_BACKEND= \
+#     .
+#
+# -----------------------------------------------------------------------------

--- a/rocm/6.4/app.conf
+++ b/rocm/6.4/app.conf
@@ -1,0 +1,52 @@
+# =============================================================================
+# ODH Base Containers - ROCm 6.4 Build Arguments
+# =============================================================================
+#
+# Build arguments for ROCm 6.4.x base image (AMD GPU workloads).
+# This file is passed directly to podman/buildah via --build-arg-file.
+#
+# Source: https://repo.radeon.com/rocm/el9/6.4.3/main/
+#
+# Usage:
+#   ./scripts/build.sh rocm-6.4
+#
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Image Tag (used by build.sh)
+# -----------------------------------------------------------------------------
+IMAGE_TAG=6.4-py312
+
+# Python version bundled with this ROCm image (used in container labels)
+PYTHON_VERSION=3.12
+
+# -----------------------------------------------------------------------------
+# Base Image
+# -----------------------------------------------------------------------------
+# Use sclorg Python image on CentOS Stream 9 (same base as CUDA images)
+# Digest is pinned for reproducible builds and auto-updated by Renovate
+# Source: https://quay.io/repository/sclorg/python-312-c9s
+BASE_IMAGE=quay.io/sclorg/python-312-c9s:c9s@sha256:5c206ec0bf9626ccf7a6b804c719310748b49d4c5c94c19f7938aa9eb3018a67
+
+# -----------------------------------------------------------------------------
+# ROCm Versions
+# Source: https://repo.radeon.com/rocm/el9/6.4.3/main/
+# -----------------------------------------------------------------------------
+ROCM_MAJOR=6
+ROCM_MAJOR_MINOR=6-4
+ROCM_MAJOR_MINOR_DOT=6.4
+ROCM_VERSION=6.4.3
+
+# -----------------------------------------------------------------------------
+# PyPI Indexes
+# PyTorch publishes ROCm-specific wheels at the rocm6.4 index.
+# -----------------------------------------------------------------------------
+PIP_INDEX_URL=https://pypi.org/simple
+PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/rocm6.4
+
+# -----------------------------------------------------------------------------
+# uv PyTorch Backend
+# Tells uv which ROCm variant to select for PyTorch wheels (uv pip install).
+# https://docs.astral.sh/uv/guides/integration/pytorch/
+# -----------------------------------------------------------------------------
+UV_TORCH_BACKEND=rocm6.4

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,8 +6,10 @@
 #
 # Targets:
 #   cuda-12.8, cuda-12.9, cuda-13.0, cuda-13.1  - Build specific CUDA version
+#   rocm-6.4                                     - Build specific ROCm version
 #   python-3.12                                  - Build specific Python version
 #   cuda                                         - Build all CUDA versions
+#   rocm                                         - Build all ROCm versions
 #   python                                       - Build all Python versions
 #   all                                          - Build everything (default)
 #
@@ -148,8 +150,10 @@ print_usage() {
     echo ""
     echo "Targets:"
     echo "  cuda-<version>    - Build specific CUDA version (e.g., cuda-12.8, cuda-13.0)"
+    echo "  rocm-<version>    - Build specific ROCm version (e.g., rocm-6.4)"
     echo "  python-<version>  - Build specific Python version (e.g., python-3.12)"
     echo "  cuda              - Build all CUDA versions"
+    echo "  rocm              - Build all ROCm versions"
     echo "  python            - Build all Python versions"
     echo "  all               - Build all images (default)"
     echo ""
@@ -159,6 +163,17 @@ print_usage() {
     if [[ -n "${cuda_versions}" ]]; then
         for v in ${cuda_versions}; do
             echo "    cuda-${v}"
+        done
+    else
+        echo "    (none found)"
+    fi
+    echo ""
+    echo "Available ROCm versions:"
+    local rocm_versions
+    rocm_versions=$(get_all_versions "rocm")
+    if [[ -n "${rocm_versions}" ]]; then
+        for v in ${rocm_versions}; do
+            echo "    rocm-${v}"
         done
     else
         echo "    (none found)"
@@ -183,6 +198,8 @@ print_usage() {
     echo "  $0 cuda-12.8      # Build CUDA 12.8 only"
     echo "  $0 cuda-13.0      # Build CUDA 13.0 only"
     echo "  $0 cuda           # Build all CUDA versions"
+    echo "  $0 rocm-6.4       # Build ROCm 6.4 only"
+    echo "  $0 rocm           # Build all ROCm versions"
     echo "  $0 python-3.12    # Build Python 3.12 only"
     echo "  $0 python         # Build all Python versions"
     echo "  $0 all            # Build everything"
@@ -210,6 +227,17 @@ main() {
             build_versioned_image "cuda" "${version}"
             ;;
 
+        # Specific ROCm version (rocm-6.4, etc.)
+        rocm-*)
+            local version="${target#rocm-}"
+            if [[ ! -d "${PROJECT_ROOT}/rocm/${version}" ]]; then
+                log_error "ROCm version ${version} not found in ${PROJECT_ROOT}/rocm/"
+                log_info "Available versions: $(get_all_versions rocm | tr '\n' ' ')"
+                exit 1
+            fi
+            build_versioned_image "rocm" "${version}"
+            ;;
+
         # Specific Python version (python-3.12, etc.)
         python-*)
             local version="${target#python-}"
@@ -226,6 +254,11 @@ main() {
             build_all_of_type "cuda"
             ;;
 
+        # All ROCm versions
+        rocm)
+            build_all_of_type "rocm"
+            ;;
+
         # All Python versions
         python)
             build_all_of_type "python"
@@ -235,6 +268,7 @@ main() {
         all)
             build_all_of_type "python"
             build_all_of_type "cuda"
+            build_all_of_type "rocm"
             ;;
 
         -h|--help|help)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,6 +43,26 @@ log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
 
+# Validate version format to prevent path traversal (e.g., ../../python/3.12)
+validate_version() {
+    local version="$1"
+    local type="$2"
+    if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+        log_error "Invalid ${type} version format: '${version}' (expected X.Y)"
+        exit 1
+    fi
+}
+
+# ROCm packages are only available for x86_64
+require_rocm_arch() {
+    local arch
+    arch=$(get_target_arch)
+    if [[ "${arch}" != "amd64" ]]; then
+        log_error "ROCm builds are only supported on x86_64/amd64 hosts (detected: ${arch})"
+        exit 1
+    fi
+}
+
 # Detect target architecture (maps uname -m to OCI arch names)
 get_target_arch() {
     local arch
@@ -219,6 +239,7 @@ main() {
         # Specific CUDA version (cuda-12.8, cuda-13.0, etc.)
         cuda-*)
             local version="${target#cuda-}"
+            validate_version "${version}" "CUDA"
             if [[ ! -d "${PROJECT_ROOT}/cuda/${version}" ]]; then
                 log_error "CUDA version ${version} not found in ${PROJECT_ROOT}/cuda/"
                 log_info "Available versions: $(get_all_versions cuda | tr '\n' ' ')"
@@ -229,7 +250,9 @@ main() {
 
         # Specific ROCm version (rocm-6.4, etc.)
         rocm-*)
+            require_rocm_arch
             local version="${target#rocm-}"
+            validate_version "${version}" "ROCm"
             if [[ ! -d "${PROJECT_ROOT}/rocm/${version}" ]]; then
                 log_error "ROCm version ${version} not found in ${PROJECT_ROOT}/rocm/"
                 log_info "Available versions: $(get_all_versions rocm | tr '\n' ' ')"
@@ -241,6 +264,7 @@ main() {
         # Specific Python version (python-3.12, etc.)
         python-*)
             local version="${target#python-}"
+            validate_version "${version}" "Python"
             if [[ ! -d "${PROJECT_ROOT}/python/${version}" ]]; then
                 log_error "Python version ${version} not found in ${PROJECT_ROOT}/python/"
                 log_info "Available versions: $(get_all_versions python | tr '\n' ' ')"
@@ -256,6 +280,7 @@ main() {
 
         # All ROCm versions
         rocm)
+            require_rocm_arch
             build_all_of_type "rocm"
             ;;
 
@@ -268,7 +293,11 @@ main() {
         all)
             build_all_of_type "python"
             build_all_of_type "cuda"
-            build_all_of_type "rocm"
+            if [[ "$(get_target_arch)" == "amd64" ]]; then
+                build_all_of_type "rocm"
+            else
+                log_warn "Skipping ROCm builds (only supported on x86_64/amd64)"
+            fi
             ;;
 
         -h|--help|help)

--- a/scripts/generate-containerfile.sh
+++ b/scripts/generate-containerfile.sh
@@ -54,6 +54,12 @@ validate_version() {
                 log_warn "CUDA version ${version} is older than 12.x - are you sure?"
             fi
             ;;
+        rocm)
+            local major="${version%%.*}"
+            if [[ "${major}" -lt 5 ]]; then
+                log_warn "ROCm version ${version} is older than 5.x - are you sure?"
+            fi
+            ;;
         python)
             local major="${version%%.*}"
             if [[ "${major}" -lt 3 ]]; then
@@ -303,20 +309,134 @@ create_cuda_appconf() {
     log_warn "See: https://gitlab.com/nvidia/container-images/cuda/-/tree/master/dist/${new_version}.x"
 }
 
+# Create a starter app.conf for a new ROCm version
+create_rocm_appconf() {
+    local new_version="$1"
+    local output_dir="$2"
+    local new_conf="${output_dir}/app.conf"
+
+    local latest
+    latest=$(find_latest_version "rocm" "${new_version}") || {
+        log_warn "No existing rocm version found; skipping app.conf generation"
+        log_warn "Create ${output_dir}/app.conf manually"
+        return
+    }
+
+    local old_conf="${PROJECT_ROOT}/rocm/${latest}/app.conf"
+    if [[ ! -f "${old_conf}" ]]; then
+        log_warn "No app.conf found at rocm/${latest}/app.conf; skipping app.conf generation"
+        return
+    fi
+
+    local old_version="${latest}"
+    local old_major="${old_version%%.*}"
+    local old_minor="${old_version#*.}"
+    local old_major_minor="${old_major}-${old_minor}"
+    local old_esc
+    old_esc=$(sed_escape "${old_version}")
+
+    local new_major="${new_version%%.*}"
+    local new_minor="${new_version#*.}"
+    local new_major_minor="${new_major}-${new_minor}"
+
+    cp "${old_conf}" "${new_conf}"
+
+    # Update derivable version fields
+    sed -i \
+        -e "s/ROCm ${old_esc}/ROCm ${new_version}/g" \
+        -e "s/rocm-${old_esc}/rocm-${new_version}/g" \
+        -e "s/^IMAGE_TAG=${old_esc}/IMAGE_TAG=${new_version}/" \
+        -e "s/^ROCM_MAJOR=${old_major}$/ROCM_MAJOR=${new_major}/" \
+        -e "s/^ROCM_MAJOR_MINOR=${old_major_minor}$/ROCM_MAJOR_MINOR=${new_major_minor}/" \
+        -e "s/^ROCM_MAJOR_MINOR_DOT=${old_esc}$/ROCM_MAJOR_MINOR_DOT=${new_version}/" \
+        "${new_conf}"
+
+    # Update repo path references (e.g., el9/6.4.3 -> el9/<new>.x)
+    sed -i \
+        -e "s|el9/${old_esc}\.[0-9]*|el9/${new_version}.x|g" \
+        "${new_conf}"
+
+    # Strip digest and leave a TODO
+    sed -i '/^BASE_IMAGE=/i # TODO: pin digest for reproducible builds' "${new_conf}"
+    sed -i 's/^\(BASE_IMAGE=.*\)@sha256:[a-f0-9]\+/\1/' "${new_conf}"
+
+    # Mark ROCm-specific version lines with TODO comments
+    local rocm_keys=(
+        ROCM_VERSION
+    )
+    for key in "${rocm_keys[@]}"; do
+        if grep -q "^${key}=" "${new_conf}" && ! grep -B1 "^${key}=" "${new_conf}" | grep -q "# TODO: update from AMD"; then
+            sed -i "/^${key}=/s/^/# TODO: update from AMD\n/" "${new_conf}"
+        fi
+    done
+
+    # Validate and update PyTorch wheel index for the new ROCm version
+    local new_torch_backend
+    if [[ -n "${TORCH_BACKEND}" ]]; then
+        new_torch_backend="${TORCH_BACKEND}"
+        log_info "Using user-specified torch backend: ${new_torch_backend}"
+    else
+        new_torch_backend="rocm${new_version}"
+    fi
+    local new_torch_index="https://download.pytorch.org/whl/${new_torch_backend}"
+
+    if [[ "${SKIP_PYTORCH_CHECK}" == "true" && -z "${TORCH_BACKEND}" ]]; then
+        log_error "--skip-pytorch-check requires --torch-backend to avoid using an"
+        log_error "auto-derived backend that may not exist."
+        log_error ""
+        log_error "Example: $0 rocm ${new_version} --skip-pytorch-check --torch-backend rocm${new_version}"
+        exit 1
+    elif [[ "${SKIP_PYTORCH_CHECK}" == "true" ]]; then
+        log_warn "Skipping PyTorch wheel index check (--skip-pytorch-check)"
+        log_warn "Using backend ${new_torch_backend} without online validation"
+    else
+        log_info "Checking PyTorch wheel index for ${new_torch_backend}..."
+        if ! check_pytorch_wheel_index "${new_torch_backend}"; then
+            log_error "No PyTorch wheel index found for ${new_torch_backend}"
+            log_error "URL checked: ${new_torch_index}/"
+            log_error "PyTorch does not publish wheels for every ROCm version."
+            log_error "Check available indexes at: https://download.pytorch.org/whl/"
+            log_error ""
+            log_error "To use a different ROCm wheel index, re-run with:"
+            log_error "  $0 rocm ${new_version} --torch-backend <backend>"
+            log_error "  Example: $0 rocm ${new_version} --torch-backend rocm${old_version}"
+            log_error ""
+            log_error "To skip this check entirely (offline/air-gapped), re-run with:"
+            log_error "  $0 rocm ${new_version} --skip-pytorch-check --torch-backend <backend>"
+            # Clean up only the files created by this run
+            rm -f "${new_conf}" "${output_dir}/Containerfile"
+            rmdir "${output_dir}" 2>/dev/null || true
+            exit 1
+        fi
+        log_info "PyTorch wheel index found: ${new_torch_index}"
+    fi
+
+    # Update PIP_EXTRA_INDEX_URL and UV_TORCH_BACKEND in app.conf
+    sed -i "s|^PIP_EXTRA_INDEX_URL=.*|PIP_EXTRA_INDEX_URL=${new_torch_index}|" "${new_conf}"
+    sed -i "s|^UV_TORCH_BACKEND=.*|UV_TORCH_BACKEND=${new_torch_backend}|" "${new_conf}"
+    log_info "Updated PIP_EXTRA_INDEX_URL to ${new_torch_index}"
+    log_info "Updated UV_TORCH_BACKEND to ${new_torch_backend}"
+
+    log_info "Generated: ${new_conf} (from rocm/${old_version}/app.conf)"
+    log_warn "ROCm-specific version values are marked with TODO and must be updated"
+    log_warn "See: https://repo.radeon.com/rocm/el9/${new_version}.x/"
+}
+
 print_usage() {
-    echo "Usage: $0 <cuda|python> <version> [options]"
+    echo "Usage: $0 <cuda|rocm|python> <version> [options]"
     echo ""
     echo "Generate a version-specific Containerfile and starter app.conf from template."
     echo ""
     echo "Arguments:"
     echo "  cuda <version>    Generate CUDA Containerfile + app.conf (e.g., 12.9, 13.0)"
+    echo "  rocm <version>    Generate ROCm Containerfile + app.conf (e.g., 6.4, 7.1)"
     echo "  python <version>  Generate Python Containerfile + app.conf (e.g., 3.12, 3.13)"
     echo ""
-    echo "Options (cuda only):"
-    echo "  --torch-backend <backend>  Use a specific PyTorch CUDA backend (e.g., cu128, cu130)"
-    echo "                             instead of auto-deriving from the CUDA version."
+    echo "Options (cuda and rocm):"
+    echo "  --torch-backend <backend>  Use a specific PyTorch backend (e.g., cu128, rocm6.4)"
+    echo "                             instead of auto-deriving from the version."
     echo "                             Useful when PyTorch doesn't publish wheels for every"
-    echo "                             CUDA minor version (e.g., CUDA 13.1 uses cu130)."
+    echo "                             minor version (e.g., CUDA 13.1 uses cu130)."
     echo "  --skip-pytorch-check       Skip the PyTorch wheel index HTTP validation."
     echo "                             Requires --torch-backend to avoid silently using"
     echo "                             an incorrect auto-derived backend."
@@ -325,6 +445,8 @@ print_usage() {
     echo "  $0 cuda 12.9                          # Auto-derives cu129, validates online"
     echo "  $0 cuda 13.1 --torch-backend cu130    # Use cu130 for CUDA 13.1"
     echo "  $0 cuda 13.2 --skip-pytorch-check --torch-backend cu132  # Skip online check (offline)"
+    echo "  $0 rocm 7.1                           # Auto-derives rocm7.1, validates online"
+    echo "  $0 rocm 7.1 --torch-backend rocm7.0   # Use rocm7.0 for ROCm 7.1"
     echo "  $0 python 3.13                        # Generate python/3.13/{Containerfile,app.conf}"
 }
 
@@ -395,6 +517,41 @@ generate_python() {
     log_info "  3. Build and test: ./scripts/build.sh python-${version}"
 }
 
+generate_rocm() {
+    local version="$1"
+
+    # Validate version format
+    validate_version "${version}" "rocm"
+
+    local output_dir="${PROJECT_ROOT}/rocm/${version}"
+    local template="${PROJECT_ROOT}/Containerfile.rocm.template"
+    local output="${output_dir}/Containerfile"
+
+    if [[ ! -f "${template}" ]]; then
+        log_error "Template not found: ${template}"
+        exit 1
+    fi
+
+    # Check if version already exists
+    check_existing_version "${output_dir}" "${version}" "rocm"
+
+    mkdir -p "${output_dir}"
+
+    cp "${template}" "${output}"
+    log_info "Generated: ${output}"
+
+    create_rocm_appconf "${version}" "${output_dir}"
+
+    log_info ""
+    log_info "Next steps:"
+    log_info "  1. Update ROCm-specific versions in rocm/${version}/app.conf"
+    log_info "     (lines marked with '# TODO: update from AMD')"
+    log_info "  2. Get version values from AMD:"
+    log_info "     https://repo.radeon.com/rocm/el9/${version}.x/"
+    log_info "  3. Pin the BASE_IMAGE digest"
+    log_info "  4. Build and test: ./scripts/build.sh rocm-${version}"
+}
+
 main() {
     # Handle help flags first (before arg count check)
     if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
@@ -421,9 +578,9 @@ main() {
                     exit 1
                 fi
                 TORCH_BACKEND="$2"
-                if [[ ! "${TORCH_BACKEND}" =~ ^cu[0-9]+$ ]]; then
+                if [[ ! "${TORCH_BACKEND}" =~ ^(cu[0-9]+|rocm[0-9]+\.[0-9]+)$ ]]; then
                     log_error "Invalid torch backend format: '${TORCH_BACKEND}'"
-                    log_error "Expected format: cu<digits> (e.g., cu128, cu130)"
+                    log_error "Expected format: cu<digits> (e.g., cu128) or rocm<major>.<minor> (e.g., rocm6.4)"
                     exit 1
                 fi
                 shift 2
@@ -443,6 +600,9 @@ main() {
     case "${type}" in
         cuda)
             generate_cuda "${version}"
+            ;;
+        rocm)
+            generate_rocm "${version}"
             ;;
         python)
             if [[ -n "${TORCH_BACKEND}" || "${SKIP_PYTORCH_CHECK}" == "true" ]]; then

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,3 +186,29 @@ def cuda_container(cuda_image):
     runner.start()
     yield runner
     runner.stop()
+
+
+@pytest.fixture(scope="session")
+def rocm_image():
+    """Image name for ROCm base image.
+
+    Set via ROCM_IMAGE environment variable.
+    Example: ROCM_IMAGE=quay.io/opendatahub/odh-midstream-rocm-base-6-4
+    """
+    return _get_required_env(
+        "ROCM_IMAGE",
+        "quay.io/opendatahub/odh-midstream-rocm-base-<rocm_major_version>-<rocm_minor_version>",
+    )
+
+
+@pytest.fixture(scope="session")
+def rocm_container(rocm_image):
+    """Session-scoped container runner for ROCm image.
+
+    Container starts once at session start and stops at session end.
+    All tests share the same running container.
+    """
+    runner = ContainerRunner(rocm_image)
+    runner.start()
+    yield runner
+    runner.stop()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -9,9 +9,9 @@ import pytest
 from tests import APP_ROOT, WORKDIR, redact_url_credentials
 
 
-@pytest.fixture(params=["python_container", "cuda_container"])
+@pytest.fixture(params=["python_container", "cuda_container", "rocm_container"])
 def container(request):
-    """Parameterize to run same tests against both images."""
+    """Parameterize to run same tests against all image types."""
     return request.getfixturevalue(request.param)
 
 

--- a/tests/test_cuda_image.py
+++ b/tests/test_cuda_image.py
@@ -165,7 +165,10 @@ def test_uv_torch_backend(cuda_container):
     # Verify it's set to a valid CUDA backend (cuNNN format), not "auto" or "cpu"
     match = re.search(r'torch-backend\s*=\s*"(cu\d+)"', result.stdout)
     assert match, f'Expected torch-backend = "cuNNN" in uv.toml, got:\n{result.stdout}'
-    # If UV_TORCH_BACKEND is set in the test environment, verify the exact value matches
+    # If UV_TORCH_BACKEND is set in the test environment, verify the exact value matches.
+    # Note: UV_TORCH_BACKEND is intentionally not passed in CI. The downstream build
+    # overwrites /etc/uv/uv.toml with its own config, so the exact value set here
+    # has no downstream impact. The loose format check above is sufficient.
     expected_backend = os.environ.get("UV_TORCH_BACKEND")
     if expected_backend is not None:
         assert match.group(1) == expected_backend, (

--- a/tests/test_rocm_image.py
+++ b/tests/test_rocm_image.py
@@ -1,0 +1,156 @@
+"""Tests specific to the ROCm base image.
+
+These tests verify ROCm-specific environment variables, libraries,
+and labels. All tests run without GPU hardware.
+"""
+
+import os
+import re
+
+import pytest
+
+# --- ROCm Environment Tests ---
+
+
+def test_rocm_version(rocm_container):
+    """Verify ROCM_VERSION environment variable matches expected version.
+
+    The expected version is controlled by the ROCM_VERSION environment variable.
+    If not set, version validation is skipped (only checks env var exists).
+    """
+    actual_version = rocm_container.get_env("ROCM_VERSION")
+    assert actual_version, "ROCM_VERSION environment variable should be set in container"
+
+    expected_version = os.environ.get("ROCM_VERSION")
+    if expected_version is None:
+        pytest.skip(
+            "ROCM_VERSION not set - skipping version validation. "
+            "Set ROCM_VERSION env var to validate specific version."
+        )
+    assert actual_version.startswith(expected_version), (
+        f"Expected ROCM_VERSION to start with {expected_version}, got {actual_version}"
+    )
+
+
+def test_rocm_home(rocm_container):
+    """Verify ROCM_HOME points to the ROCm installation directory.
+
+    PyTorch and other ML frameworks use ROCM_HOME to locate the ROCm toolkit.
+    """
+    assert rocm_container.get_env("ROCM_HOME") == "/opt/rocm"
+
+
+def test_rocm_in_path(rocm_container):
+    """Verify ROCm bin directory is in PATH."""
+    assert "/opt/rocm/bin" in rocm_container.get_env("PATH")
+
+
+# --- ROCm Directory Tests ---
+
+
+def test_rocm_dir_exists(rocm_container):
+    """Verify ROCm installation directory exists."""
+    assert rocm_container.dir_exists("/opt/rocm")
+
+
+# --- ROCm Library Tests ---
+
+
+def test_libamdhip64_present(rocm_container):
+    """Verify HIP runtime library is present.
+
+    Core AMD HIP runtime library, equivalent to CUDA's libcudart.
+    Installed via hip-runtime-amd package.
+    """
+    result = rocm_container.run("ldconfig -p | grep libamdhip64")
+    assert result.returncode == 0, (
+        "libamdhip64.so not found - hip-runtime-amd package may be missing"
+    )
+
+
+def test_librocblas_present(rocm_container):
+    """Verify rocBLAS library is present.
+
+    BLAS library for AMD GPUs, equivalent to CUDA's libcublas.
+    Installed via rocblas package.
+    """
+    result = rocm_container.run("ldconfig -p | grep librocblas")
+    assert result.returncode == 0, "librocblas.so not found - rocblas package may be missing"
+
+
+def test_librccl_present(rocm_container):
+    """Verify RCCL (ROCm Communication Collectives Library) is present.
+
+    Required for multi-GPU and distributed training with PyTorch.
+    Equivalent to NVIDIA's NCCL. Installed via rccl package.
+    """
+    result = rocm_container.run("ldconfig -p | grep librccl")
+    assert result.returncode == 0, "librccl.so not found - rccl package may be missing"
+
+
+def test_libMIOpen_present(rocm_container):
+    """Verify MIOpen library is present.
+
+    AMD's deep learning primitives library, equivalent to CUDA's cuDNN.
+    Installed via miopen-hip package.
+    """
+    result = rocm_container.run("ldconfig -p | grep libMIOpen")
+    assert result.returncode == 0, "libMIOpen.so not found - miopen-hip package may be missing"
+
+
+def test_librocfft_present(rocm_container):
+    """Verify rocFFT library is present.
+
+    FFT library for AMD GPUs. Installed via rocfft package.
+    """
+    result = rocm_container.run("ldconfig -p | grep librocfft")
+    assert result.returncode == 0, "librocfft.so not found - rocfft package may be missing"
+
+
+def test_librocsolver_present(rocm_container):
+    """Verify rocSOLVER library is present.
+
+    Linear algebra solver library for AMD GPUs.
+    Installed via rocsolver package.
+    """
+    result = rocm_container.run("ldconfig -p | grep librocsolver")
+    assert result.returncode == 0, "librocsolver.so not found - rocsolver package may be missing"
+
+
+# --- ROCm Label Tests ---
+
+
+def test_rocm_version_label(rocm_container):
+    """Verify ROCm version label is present."""
+    assert "com.amd.rocm.version" in rocm_container.get_labels()
+
+
+def test_uv_torch_backend(rocm_container):
+    """Verify torch-backend is configured in uv.toml for ROCm wheel selection.
+
+    Uses a specific backend (e.g. rocm6.4) rather than "auto" because
+    auto detects GPU drivers at runtime, which are absent during container builds.
+    Configured via uv.toml (not ENV) to avoid uv erroring on empty values.
+    """
+    result = rocm_container.run("cat /etc/uv/uv.toml")
+    assert result.returncode == 0, "Failed to read /etc/uv/uv.toml"
+    assert "torch-backend" in result.stdout, (
+        "torch-backend should be configured in /etc/uv/uv.toml for ROCm images"
+    )
+    # Verify it's set to a valid ROCm backend (rocmX.Y format), not "auto" or "cpu"
+    match = re.search(r'torch-backend\s*=\s*"(rocm\d+\.\d+)"', result.stdout)
+    assert match, f'Expected torch-backend = "rocmX.Y" in uv.toml, got:\n{result.stdout}'
+    # If UV_TORCH_BACKEND is set in the test environment, verify the exact value matches.
+    # Note: UV_TORCH_BACKEND is intentionally not passed in CI. The downstream build
+    # overwrites /etc/uv/uv.toml with its own config, so the exact value set here
+    # has no downstream impact. The loose format check above is sufficient.
+    expected_backend = os.environ.get("UV_TORCH_BACKEND")
+    if expected_backend is not None:
+        assert match.group(1) == expected_backend, (
+            f'Expected torch-backend = "{expected_backend}", got "{match.group(1)}"'
+        )
+
+
+def test_accelerator_label_rocm(rocm_container):
+    """Verify accelerator label is 'rocm' for ROCm image."""
+    assert rocm_container.get_labels().get("com.opendatahub.accelerator") == "rocm"


### PR DESCRIPTION
Add AMD ROCm GPU base image infrastructure mirroring the existing CUDA pattern. This establishes the ROCm build system so future versions can be added incrementally.

Closes: #164


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-class ROCm support: per-version ROCm base image generation, build targets, and ROCm 6.4 pipeline runs for PRs and pushes.

* **Tests**
  * New ROCm image test suite and session fixtures; CI runs ROCm validation per-detected ROCm version.

* **Chores**
  * CI matrix and gating extended to include ROCm, build tooling and templates updated for ROCm, dependency update tooling and packaging config adjusted, and repository ignore rules extended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->