### PR TITLE
Add auto-merge workflow and merge queue support

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,30 @@
+name: Auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+    branches: [main]
+
+jobs:
+  enable-auto-merge:
+    if: >-
+      github.event.pull_request.draft == false &&
+      (github.event.pull_request.author_association == 'MEMBER' ||
+       github.event.pull_request.author_association == 'OWNER' ||
+       github.event.pull_request.author_association == 'COLLABORATOR' ||
+       github.event.pull_request.author_association == 'CONTRIBUTOR' ||
+       github.event.pull_request.user.type == 'Bot')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: getsentry/action-github-app-token@v2
+        with:
+          app_id: ${{ secrets.ODH_DEVOPS_APP_ID }}
+          private_key: ${{ secrets.ODH_DEVOPS_APP_PRIVATE_KEY }}
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --merge "$PR_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,31 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
     branches: [main]
+  merge_group:
 
 env:
   IMAGE_REGISTRY: localhost
 
 jobs:
+  authorize:
+    name: Authorize
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR' ||
+      github.event.pull_request.author_association == 'CONTRIBUTOR' ||
+      github.event.pull_request.user.type == 'Bot' ||
+      contains(toJSON(github.event.pull_request.labels.*.name), 'ok-to-test')
+    steps:
+      - run: echo "Authorized"
+
   changes:
     name: Detect Changes
+    needs: [authorize]
     runs-on: ubuntu-latest
     outputs:
       any-cuda: ${{ steps.filter.outputs['any-cuda'] }}
@@ -138,6 +155,7 @@ jobs:
 
   lint:
     name: Lint (ruff)
+    needs: [authorize]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -158,6 +176,7 @@ jobs:
 
   type-check:
     name: Type Check (mypy)
+    needs: [authorize]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -175,6 +194,7 @@ jobs:
 
   detect-containerfile-changes:
     name: Detect Containerfile Changes
+    needs: [authorize]
     runs-on: ubuntu-latest
     outputs:
       containerfiles_changed: ${{ steps.changed.outputs.any_changed }}
@@ -461,8 +481,9 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && needs.authorize.result == 'success'
     needs:
+      - authorize
       - lint
       - type-check
       - lint-containerfiles

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -1,0 +1,27 @@
+name: OK to Test
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  ok-to-test:
+    name: OK to Test
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/ok-to-test' &&
+      (github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'COLLABORATOR' ||
+       github.event.comment.author_association == 'CONTRIBUTOR')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add ok-to-test label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "ok-to-test"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -157,6 +157,7 @@ GitHub Actions automatically runs on every PR and push to `main`:
 
 | Job | Trigger | Description |
 |-----|---------|-------------|
+| `authorize` | PR, push | Gates CI for non-org contributors (see below) |
 | `lint` | PR, push | Runs `ruff check` and `ruff format --check` |
 | `type-check` | PR, push | Runs `mypy` type checking |
 | `lint-containerfiles` | PR, push | Lints changed Containerfiles with Hadolint |
@@ -171,6 +172,34 @@ when changes do not apply.
 
 Version matrices are built dynamically from the directory structure (`cuda/*/`, `rocm/*/`, `python/*/`).
 No manual CI updates are needed when adding new versions.
+
+### CI Authorization for External Contributors
+
+CI does not run automatically on PRs from external contributors (non-org members).
+This prevents untrusted code from consuming CI resources without review.
+
+| PR author | CI behavior |
+|-----------|-------------|
+| Organization member, collaborator, or prior contributor | Runs automatically |
+| GitHub App bot (Renovate, Mintmaker) | Runs automatically |
+| First-time contributor | Skipped until a maintainer approves |
+
+To approve CI for an external PR, a maintainer comments on the PR:
+
+```
+/ok-to-test
+```
+
+This adds the `ok-to-test` label, which triggers the CI pipeline. The label
+persists across subsequent pushes, so CI will continue to run on updates to the
+PR without needing repeated approval.
+
+### Auto-merge
+
+The auto-merge workflow (`auto-merge.yml`) automatically enables GitHub's
+auto-merge on PRs from organization members, collaborators, prior contributors, and bots. Once all
+required checks pass and the PR has the necessary approvals, GitHub merges it
+automatically. PRs from external contributors are excluded from auto-merge.
 
 ### Before Submitting a PR
 


### PR DESCRIPTION
Add auto-merge, CI authorization gate, and /ok-to-test workflow
    
 - Auto-merge workflow enables GitHub auto-merge for org members and bots
 - CI gated behind authorize job to skip runs for external contributors
 - /ok-to-test comment from maintainers adds label to trigger CI
 - Add merge_group trigger to CI for merge queue support
 - Document CI authorization and auto-merge in DEVELOPMENT.md


Closes #183



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to enable automatic merging of pull requests once they are ready (skips drafts).
  * Expanded CI triggers to include additional merge-related events so pipeline runs cover more merge scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->