### PR TITLE
Add ROCm references to project documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This repository provides standardized Containerfiles for building Open Data Hub 
 |--------|------------------|------------------------|
 | Python | UBI 9            | 3.12                   |
 | CUDA   | CentOS Stream 9  | 12.8, 12.9, 13.0, 13.1, 13.2 |
+| ROCm   | CentOS Stream 9  | 6.4                    |
 
 ## Repository Structure
 
@@ -29,6 +30,10 @@ base-containers/
 │   └── 13.2/
 │       ├── Containerfile
 │       └── app.conf
+├── rocm/                                 # ROCm version directories
+│   └── 6.4/
+│       ├── Containerfile                 # ROCm 6.4 Containerfile
+│       └── app.conf                      # ROCm 6.4 build arguments
 ├── python/                               # Python version directories
 │   └── 3.12/
 │       ├── Containerfile                 # Python 3.12 Containerfile
@@ -37,7 +42,8 @@ base-containers/
 │   ├── conftest.py                       # Shared fixtures
 │   ├── test_common.py                    # Tests for both image types
 │   ├── test_cuda_image.py                # CUDA-specific tests
-│   └── test_python_image.py              # Python-specific tests
+│   ├── test_python_image.py              # Python-specific tests
+│   └── test_rocm_image.py                # ROCm-specific tests
 ├── scripts/
 │   ├── build.sh                          # Main build script
 │   ├── generate-containerfile.sh         # Generate Containerfile + app.conf from template
@@ -46,6 +52,7 @@ base-containers/
 │   └── fix-permissions                   # OpenShift permission fixer
 ├── docs/
 │   ├── ADDING-PYTHON-VERSION.md          # Guide for adding Python versions
+│   ├── ADDING-ROCM-VERSION.md            # Guide for adding ROCm versions
 │   ├── DEVELOPMENT.md                    # Development setup and workflow
 │   └── RATIONALE.md                      # Project motivation
 ├── .github/
@@ -56,6 +63,7 @@ base-containers/
 │   └── *.yaml                            # Push/PR pipelines per image
 ├── Containerfile.cuda.template           # Template for new CUDA versions
 ├── Containerfile.python.template         # Template for new Python versions
+├── Containerfile.rocm.template           # Template for new ROCm versions
 ├── pyproject.toml                        # Python project configuration
 ├── tox.ini                               # Test automation (lint, type, test)
 ├── renovate.json                         # Renovate bot configuration
@@ -72,10 +80,12 @@ base-containers/
 ./scripts/build.sh cuda-13.0              # Build CUDA 13.0 image
 ./scripts/build.sh cuda-13.1              # Build CUDA 13.1 image
 ./scripts/build.sh cuda-13.2              # Build CUDA 13.2 image
+./scripts/build.sh rocm-6.4               # Build ROCm 6.4 image
 ./scripts/build.sh python-3.12            # Build Python 3.12 image
 
 # Build all versions of a type
 ./scripts/build.sh cuda                   # Build all CUDA versions
+./scripts/build.sh rocm                   # Build all ROCm versions
 ./scripts/build.sh python                 # Build all Python versions
 
 # Build everything
@@ -98,62 +108,38 @@ Tests use pytest with session-scoped container fixtures. Images must be built fi
 
 ```bash
 # Run all tests
-PYTHON_IMAGE=<image:tag> CUDA_IMAGE=<image:tag> pytest tests/ -v
+PYTHON_IMAGE=<image:tag> CUDA_IMAGE=<image:tag> ROCM_IMAGE=<image:tag> pytest tests/ -v
 
 # Run Python image tests only
 PYTHON_IMAGE=<image:tag> PYTHON_VERSION=3.12 pytest tests/test_python_image.py tests/test_common.py -v
 
 # Run CUDA image tests only
 CUDA_IMAGE=<image:tag> CUDA_VERSION=12.8 pytest tests/test_cuda_image.py tests/test_common.py -v
+
+# Run ROCm image tests only (x86_64 only)
+ROCM_IMAGE=<image:tag> ROCM_VERSION=6.4 pytest tests/test_rocm_image.py tests/test_common.py -v
 ```
 
 | Variable | Description |
 |----------|-------------|
 | `PYTHON_IMAGE` | Python image to test (e.g., `localhost/odh-midstream-python-base:py312`) |
 | `CUDA_IMAGE` | CUDA image to test (e.g., `localhost/odh-midstream-cuda-base:12.8-py312`) |
+| `ROCM_IMAGE` | ROCm image to test (e.g., `localhost/odh-midstream-rocm-base:6.4-py312`) |
 | `PYTHON_VERSION` | Expected Python version for validation |
 | `CUDA_VERSION` | Expected CUDA version for validation |
+| `ROCM_VERSION` | Expected ROCm version for validation |
 
 Tests are skipped if the corresponding image variable is not set.
 
 ## Adding New Versions
 
-### Adding a New CUDA Version
+```bash
+./scripts/generate-containerfile.sh <type> <version>   # e.g., cuda 13.2, rocm 6.5, python 3.13
+```
 
-1. Generate the Containerfile and starter app.conf from template:
-   ```bash
-   ./scripts/generate-containerfile.sh cuda 13.2
-   ```
-
-2. Update NVIDIA-specific versions in `cuda/13.2/app.conf` (lines marked with `# TODO`):
-   - Get version numbers from [NVIDIA CUDA Dockerfiles](https://gitlab.com/nvidia/container-images/cuda/-/tree/master/dist)
-   - Pin the BASE_IMAGE digest
-
-3. Build and test:
-   ```bash
-   ./scripts/build.sh cuda-13.2
-   ```
-
-### Adding a New Python Version
-
-1. Generate the Containerfile and starter app.conf from template:
-   ```bash
-   ./scripts/generate-containerfile.sh python 3.13
-   ```
-
-2. Review `python/3.13/app.conf` (version strings are updated automatically):
-   - Pin the BASE_IMAGE digest
-   - Verify all values are correct
-
-3. Build and test:
-   ```bash
-   ./scripts/build.sh python-3.13
-   ```
-
-4. (Optional) Make it the project default across CI and tooling:
-   ```bash
-   ./scripts/update-default-python-version.sh 3.13 --apply
-   ```
+See the detailed guides:
+- [Adding a Python version](docs/ADDING-PYTHON-VERSION.md)
+- [Adding a ROCm version](docs/ADDING-ROCM-VERSION.md)
 
 ## Build System
 
@@ -171,6 +157,8 @@ Config files in `<type>/<version>/app.conf` are passed directly to podman via `-
 ### Template Build Args
 - CUDA templates use build args from `cuda/<version>/app.conf`:
   `CUDA_MAJOR` (12), `CUDA_MAJOR_MINOR` (12-8), `CUDA_MAJOR_MINOR_DOT` (12.8)
+- ROCm templates use build args from `rocm/<version>/app.conf`:
+  `ROCM_MAJOR` (6), `ROCM_MAJOR_MINOR` (6-4), `ROCM_MAJOR_MINOR_DOT` (6.4)
 - Python templates use build args from `python/<version>/app.conf`:
   `PYTHON_VERSION` (3.12), `PYTHON_VERSION_NODOT` (312)
 
@@ -225,6 +213,8 @@ To manually check for new versions:
 ## External Resources
 
 - [NVIDIA CUDA Dockerfiles](https://gitlab.com/nvidia/container-images/cuda/-/tree/master/dist)
+- [AMD ROCm Installation](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/)
+- [ROCm Package Repository](https://repo.radeon.com/rocm/)
 - [UBI Python Images](https://catalog.redhat.com/software/containers/ubi9/python-312)
 - [uv Package Manager](https://github.com/astral-sh/uv/releases)
 - [buildah-build(1) documentation](https://github.com/containers/buildah/blob/main/docs/buildah-build.1.md)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ For development setup and workflow, see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.m
 |--------|------------------------|------------------|
 | Python | 3.12                   | UBI 9            |
 | CUDA   | 12.8, 12.9, 13.0, 13.1, 13.2 | CentOS Stream 9  |
+| ROCm   | 6.4                    | CentOS Stream 9  |
 
 ## Pulling Base Images
 
@@ -49,6 +50,17 @@ podman pull quay.io/opendatahub/odh-midstream-cuda-base-12-8
 podman pull quay.io/opendatahub/odh-midstream-cuda-base-13-2
 ```
 
+### ROCm Images
+
+| Version | Image | Quay.io Repository |
+|---------|-------|-------------------|
+| 6.4 | `quay.io/opendatahub/odh-midstream-rocm-base-6-4` | [View on Quay.io](https://quay.io/repository/opendatahub/odh-midstream-rocm-base-6-4) |
+
+```bash
+# Pull ROCm 6.4 base image (x86_64 only)
+podman pull quay.io/opendatahub/odh-midstream-rocm-base-6-4
+```
+
 ## Repository Structure
 
 Each image type has version-specific directories containing a `Containerfile` and `app.conf`:
@@ -56,6 +68,8 @@ Each image type has version-specific directories containing a `Containerfile` an
 ```text
 cuda/<version>/Containerfile      # CUDA image definition
 cuda/<version>/app.conf           # CUDA build arguments
+rocm/<version>/Containerfile      # ROCm image definition
+rocm/<version>/app.conf           # ROCm build arguments
 python/<version>/Containerfile    # Python image definition
 python/<version>/app.conf         # Python build arguments
 ```
@@ -69,7 +83,7 @@ python/<version>/app.conf         # Python build arguments
 ./scripts/build.sh <type>-<version>    # e.g., cuda-12.8, python-3.12
 
 # Build all versions of a type
-./scripts/build.sh <type>              # e.g., cuda, python
+./scripts/build.sh <type>              # e.g., cuda, rocm, python
 
 # Build everything
 ./scripts/build.sh all
@@ -92,15 +106,17 @@ podman build -t odh-midstream-cuda-base:12.8-py312 \
   -f cuda/12.8/Containerfile .
 ```
 
-## Why Two Base Images?
+## Why Different Base Images?
 
 | Template | Base | Reason |
 |----------|------|--------|
 | Python (CPU) | UBI 9 | Smaller footprint, Red Hat supported |
 | CUDA (GPU) | CentOS Stream 9 | CUDA requires OpenGL/mesa libs not in UBI 9 |
+| ROCm (GPU) | CentOS Stream 9 | ROCm packages need CentOS Stream 9 / RHEL 9 repos |
 
 **Note:** 
 * CUDA packages fail on UBI 9 due to missing dependencies (OpenGL, mesa libs). CentOS Stream 9 includes these libraries.
+* ROCm images are x86_64 only — AMD does not provide ARM64 ROCm packages.
 * Python images remain on UBI 9 to minimize migration impact. A unified CentOS Stream 9 base for all images may be considered in the future.
 
 ## Common Properties
@@ -143,25 +159,28 @@ COPY --chown=1001:0 . .
 CMD ["python", "train.py"]
 ```
 
+### ROCm Application
+
+```dockerfile
+FROM quay.io/opendatahub/odh-midstream-rocm-base-6-4
+
+# pip and uv are pre-configured with PyPI + PyTorch ROCm indexes
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY --chown=1001:0 . .
+CMD ["python", "train.py"]
+```
+
 ## Adding New Versions
 
-Use the generation script to create a new version from the template:
-
 ```bash
-# Generate Containerfile from template
-./scripts/generate-containerfile.sh <type> <version>
-
-# Example: Add CUDA 13.2
-./scripts/generate-containerfile.sh cuda 13.2
-# Then create cuda/13.2/app.conf with version-specific values
-# Include CUDA_MAJOR, CUDA_MAJOR_MINOR, CUDA_MAJOR_MINOR_DOT
-# Get versions from: https://gitlab.com/nvidia/container-images/cuda/-/tree/master/dist
-
-# Example: Add Python 3.13
-./scripts/generate-containerfile.sh python 3.13
-# Then create python/3.13/app.conf with version-specific values
-# Include PYTHON_VERSION and PYTHON_VERSION_NODOT
+./scripts/generate-containerfile.sh <type> <version>   # e.g., cuda 13.2, rocm 6.5, python 3.13
 ```
+
+See the detailed guides:
+- [Adding a Python version](docs/ADDING-PYTHON-VERSION.md)
+- [Adding a ROCm version](docs/ADDING-ROCM-VERSION.md)
 
 ## Build Arguments
 

--- a/docs/ADDING-ROCM-VERSION.md
+++ b/docs/ADDING-ROCM-VERSION.md
@@ -1,0 +1,71 @@
+# Adding a New ROCm Version
+
+> **Note:** ROCm images are x86_64 only -- AMD does not provide ARM64 ROCm packages.
+
+## Quick Start
+
+```bash
+# 1. Create the version directory, Containerfile, and starter app.conf
+./scripts/generate-containerfile.sh rocm 6.5
+
+# 2. Update rocm/6.5/app.conf (pin BASE_IMAGE digest, set ROCm version numbers)
+
+# 3. Build, lint, and test
+./scripts/build.sh rocm-6.5
+./scripts/lint-containerfile.sh rocm/6.5/Containerfile
+```
+
+## Step-by-Step
+
+### 1. Generate the version directory
+
+```bash
+./scripts/generate-containerfile.sh rocm 6.5
+```
+
+This creates:
+- `rocm/6.5/Containerfile` (from the template)
+- `rocm/6.5/app.conf` (copied from the latest existing version with version strings updated)
+
+### 2. Update `rocm/6.5/app.conf`
+
+The generate script auto-updates version strings (`ROCM_MAJOR`, `ROCM_MAJOR_MINOR`, `ROCM_MAJOR_MINOR_DOT`, `PIP_EXTRA_INDEX_URL`, `UV_TORCH_BACKEND`). You still need to:
+
+- **Pin the `BASE_IMAGE` digest** -- look up from [quay.io/sclorg/python-312-c9s](https://quay.io/repository/sclorg/python-312-c9s), or let Renovate auto-pin it
+- **Set `ROCM_VERSION`** to the full patch version (e.g., `6.5.0`) -- find it at [repo.radeon.com/rocm/el9/](https://repo.radeon.com/rocm/el9/)
+- **Verify** `PIP_EXTRA_INDEX_URL` and `UV_TORCH_BACKEND` match the new version
+
+### 3. Build, lint, and test
+
+```bash
+./scripts/build.sh rocm-6.5
+```
+
+Lint the generated Containerfile:
+```bash
+./scripts/lint-containerfile.sh rocm/6.5/Containerfile
+```
+
+Run the image tests (the image tag comes from `IMAGE_TAG` in `app.conf`):
+```bash
+ROCM_IMAGE=localhost/odh-midstream-rocm-base:6.5-py312 \
+ROCM_VERSION=6.5 \
+  pytest tests/test_rocm_image.py tests/test_common.py -v
+```
+
+### 4. Add Tekton pipelines
+
+Create Konflux pipeline definitions for the new version:
+- `.tekton/odh-midstream-rocm-base-<major>-<minor>-pull-request.yaml`
+- `.tekton/odh-midstream-rocm-base-<major>-<minor>-push.yaml`
+
+Copy from an existing ROCm version's pipeline files and update version references.
+
+### 5. Review and submit
+
+```bash
+git diff
+# Review changes, then open a PR
+```
+
+If the script fails partway through, revert with `git checkout -- .` and re-run.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -92,6 +92,9 @@ Use the build script to build container images:
 # Build CUDA image
 ./scripts/build.sh cuda
 
+# Build ROCm image (x86_64 only)
+./scripts/build.sh rocm
+
 # Build all images
 ./scripts/build.sh all
 ```
@@ -105,6 +108,7 @@ Tests require the container images to be built first and their names passed via 
 ```bash
 PYTHON_IMAGE=quay.io/opendatahub/odh-midstream-python-base-3-12 \
 CUDA_IMAGE=quay.io/opendatahub/odh-midstream-cuda-base-12-8 \
+ROCM_IMAGE=quay.io/opendatahub/odh-midstream-rocm-base-6-4 \
 tox -e test
 ```
 
@@ -119,6 +123,9 @@ PYTHON_IMAGE=<image:tag> pytest tests/test_python_image.py tests/test_common.py 
 
 # Run only CUDA image tests
 CUDA_IMAGE=<image:tag> pytest tests/test_cuda_image.py tests/test_common.py -v
+
+# Run only ROCm image tests (x86_64 only)
+ROCM_IMAGE=<image:tag> pytest tests/test_rocm_image.py tests/test_common.py -v
 ```
 
 ### Test Environment Variables
@@ -127,11 +134,13 @@ CUDA_IMAGE=<image:tag> pytest tests/test_cuda_image.py tests/test_common.py -v
 |----------|-------------|---------|
 | `PYTHON_IMAGE` | Python base image to test | `quay.io/opendatahub/odh-midstream-python-base-3-12` |
 | `CUDA_IMAGE` | CUDA base image to test | `quay.io/opendatahub/odh-midstream-cuda-base-12-8` |
+| `ROCM_IMAGE` | ROCm base image to test (x86_64 only) | `quay.io/opendatahub/odh-midstream-rocm-base-6-4` |
 | `PYTHON_VERSION` | Expected Python version for validation | `3.12` |
 | `CUDA_VERSION` | Expected CUDA version for validation | `12.8`, `12.9`, `13.0`, `13.1`, `13.2` |
+| `ROCM_VERSION` | Expected ROCm version for validation | `6.4` |
 
-If `PYTHON_IMAGE` or `CUDA_IMAGE` is not set, the corresponding tests will be skipped.
-If `PYTHON_VERSION` or `CUDA_VERSION` is not set, version validation tests will be skipped with a message.
+If `PYTHON_IMAGE`, `CUDA_IMAGE`, or `ROCM_IMAGE` is not set, the corresponding tests will be skipped.
+If `PYTHON_VERSION`, `CUDA_VERSION`, or `ROCM_VERSION` is not set, version validation tests will be skipped with a message.
 
 **Note:** Always set the version environment variable to match the image being tested. For example, to test CUDA 13.0:
 
@@ -153,13 +162,14 @@ GitHub Actions automatically runs on every PR and push to `main`:
 | `lint-containerfiles` | PR, push | Lints changed Containerfiles with Hadolint |
 | `test-python-image` | PR, push | Builds Python image and runs tests when Python-related files change |
 | `test-cuda-image` | PR, push | Builds CUDA image and runs tests when CUDA-related files change |
+| `test-rocm-image` | PR, push | Builds ROCm image and runs tests when ROCm-related files change |
 | `ci-status` | PR, push | Aggregates required jobs for branch protection |
 
 The `ci-status` job always runs and fails if any required job fails or is cancelled.
 Conditional jobs (like `lint-containerfiles` and `test-cuda-image`) may be skipped
 when changes do not apply.
 
-Version matrices are built dynamically from the directory structure (`cuda/*/`, `python/*/`).
+Version matrices are built dynamically from the directory structure (`cuda/*/`, `rocm/*/`, `python/*/`).
 No manual CI updates are needed when adding new versions.
 
 ### Before Submitting a PR

--- a/docs/RATIONALE.md
+++ b/docs/RATIONALE.md
@@ -56,7 +56,8 @@ Provide **common base images** that ODH repositories can build upon:
 | Base Image | Use Case |
 |------------|----------|
 | `Containerfile.python` | CPU workloads, web services |
-| `Containerfile.cuda` | GPU workloads, model training (multiple CUDA versions: 12.8, 12.9, 13.0, 13.1, 13.2) |
+| `Containerfile.cuda` | GPU workloads, model training on NVIDIA hardware (multiple CUDA versions: 12.8, 12.9, 13.0, 13.1, 13.2) |
+| `Containerfile.rocm` | GPU workloads, model training on AMD hardware (ROCm 6.4, x86_64 only) |
 
 ### Benefits
 
@@ -110,6 +111,7 @@ This approach lets consumers pick the CUDA version that matches their needs:
 |-------|---------|--------|
 | Python | UBI 9 | Smaller footprint, Red Hat supported |
 | CUDA | CentOS Stream 9 | CUDA requires OpenGL/mesa libs not in UBI 9 |
+| ROCm | CentOS Stream 9 | ROCm packages need CentOS Stream 9 / RHEL 9 repos |
 
 CUDA packages fail on UBI 9 due to missing dependencies. CentOS Stream 9 provides the required libraries. See [RHAIENG-1532](https://issues.redhat.com/browse/RHAIENG-1532).
 


### PR DESCRIPTION
Commit 5e053ba added ROCm 6.4 support but did not update documentation. Add ROCm to all existing docs.
