### PR TITLE
Add Mergify auto-merge configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,25 @@
+# Mergify Configuration for ODH Base Containers
+# https://docs.mergify.com/configuration/file-format/
+
+pull_request_rules:
+  - name: Auto-merge when all conditions met
+    conditions:
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - "-draft"
+      - "base=main"
+      - "label!=do-not-merge"
+      - "-conflict"
+    actions:
+      merge:
+        method: merge
+
+  - name: Ping author on conflicts
+    conditions:
+      - "conflict"
+      - "-closed"
+    actions:
+      comment:
+        message: |
+          This pull request has merge conflicts that must be resolved before it can be merged.
+          @{{ author }} please rebase your branch.


### PR DESCRIPTION
Enable automatic merging of approved PRs using Mergify, which is already used across the opendatahub-io org. PRs targeting main will auto-merge when they have at least 1 approval, no changes requested, and no conflicts. Includes conflict detection that pings the PR author.

