### PR TITLE
chore: add clair-scan memory overrides to ROCm 6.4 Tekton pipelines

### DIFF
--- a/.tekton/odh-midstream-rocm-base-6-4-pull-request.yaml
+++ b/.tekton/odh-midstream-rocm-base-6-4-pull-request.yaml
@@ -45,6 +45,20 @@ spec:
   pipelineRef:
     name: odh-base-containers-pull-request
   taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+        - name: oci-attach-report
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-rocm-base-6-4-push.yaml
+++ b/.tekton/odh-midstream-rocm-base-6-4-push.yaml
@@ -42,6 +42,20 @@ spec:
   pipelineRef:
     name: odh-base-containers-push
   taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+        - name: oci-attach-report
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check


### PR DESCRIPTION
ROCm images are large enough to OOMKill the scanner at default memory limits.

The ROCm 7.1 pipelines needed clair-scan memory overrides (4Gi/8Gi) to prevent OOMKilled during vulnerability scanning. Adding the same overrides to the ROCm 6.4 pipelines to keep both ROCm images' Konflux config consistent and prevent the same issue if 6.4 image size grows.

Closes #191
