### PR TITLE
docs: update documentation for ROCm 7.1 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This repository provides standardized Containerfiles for building Open Data Hub 
 |--------|------------------|------------------------|
 | Python | UBI 9            | 3.12                   |
 | CUDA   | CentOS Stream 9  | 12.8, 12.9, 13.0, 13.1, 13.2 |
-| ROCm   | CentOS Stream 9  | 6.4                    |
+| ROCm   | CentOS Stream 9  | 6.4, 7.1               |
 
 ## Repository Structure
 
@@ -31,9 +31,12 @@ base-containers/
 │       ├── Containerfile
 │       └── app.conf
 ├── rocm/                                 # ROCm version directories
-│   └── 6.4/
-│       ├── Containerfile                 # ROCm 6.4 Containerfile
-│       └── app.conf                      # ROCm 6.4 build arguments
+│   ├── 6.4/
+│   │   ├── Containerfile                 # ROCm 6.4 Containerfile
+│   │   └── app.conf                      # ROCm 6.4 build arguments
+│   └── 7.1/
+│       ├── Containerfile                 # ROCm 7.1 Containerfile
+│       └── app.conf                      # ROCm 7.1 build arguments
 ├── python/                               # Python version directories
 │   └── 3.12/
 │       ├── Containerfile                 # Python 3.12 Containerfile
@@ -81,6 +84,7 @@ base-containers/
 ./scripts/build.sh cuda-13.1              # Build CUDA 13.1 image
 ./scripts/build.sh cuda-13.2              # Build CUDA 13.2 image
 ./scripts/build.sh rocm-6.4               # Build ROCm 6.4 image
+./scripts/build.sh rocm-7.1               # Build ROCm 7.1 image
 ./scripts/build.sh python-3.12            # Build Python 3.12 image
 
 # Build all versions of a type

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For development setup and workflow, see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.m
 |--------|------------------------|------------------|
 | Python | 3.12                   | UBI 9            |
 | CUDA   | 12.8, 12.9, 13.0, 13.1, 13.2 | CentOS Stream 9  |
-| ROCm   | 6.4                    | CentOS Stream 9  |
+| ROCm   | 6.4, 7.1               | CentOS Stream 9  |
 
 ## Pulling Base Images
 
@@ -55,10 +55,14 @@ podman pull quay.io/opendatahub/odh-midstream-cuda-base-13-2
 | Version | Image | Quay.io Repository |
 |---------|-------|-------------------|
 | 6.4 | `quay.io/opendatahub/odh-midstream-rocm-base-6-4` | [View on Quay.io](https://quay.io/repository/opendatahub/odh-midstream-rocm-base-6-4) |
+| 7.1 | `quay.io/opendatahub/odh-midstream-rocm-base-7-1` | [View on Quay.io](https://quay.io/repository/opendatahub/odh-midstream-rocm-base-7-1) |
 
 ```bash
 # Pull ROCm 6.4 base image (x86_64 only)
 podman pull quay.io/opendatahub/odh-midstream-rocm-base-6-4
+
+# Pull ROCm 7.1 base image (x86_64 only)
+podman pull quay.io/opendatahub/odh-midstream-rocm-base-7-1
 ```
 
 ## Repository Structure
@@ -163,6 +167,7 @@ CMD ["python", "train.py"]
 
 ```dockerfile
 FROM quay.io/opendatahub/odh-midstream-rocm-base-6-4
+# Or ROCm 7.1: FROM quay.io/opendatahub/odh-midstream-rocm-base-7-1
 
 # pip and uv are pre-configured with PyPI + PyTorch ROCm indexes
 COPY requirements.txt .

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -116,7 +116,7 @@ tox -e test
 
 ```bash
 # Run all tests
-PYTHON_IMAGE=<image:tag> CUDA_IMAGE=<image:tag> pytest tests/ -v
+PYTHON_IMAGE=<image:tag> CUDA_IMAGE=<image:tag> ROCM_IMAGE=<image:tag> pytest tests/ -v
 
 # Run only Python image tests
 PYTHON_IMAGE=<image:tag> pytest tests/test_python_image.py tests/test_common.py -v
@@ -137,7 +137,7 @@ ROCM_IMAGE=<image:tag> pytest tests/test_rocm_image.py tests/test_common.py -v
 | `ROCM_IMAGE` | ROCm base image to test (x86_64 only) | `quay.io/opendatahub/odh-midstream-rocm-base-6-4` |
 | `PYTHON_VERSION` | Expected Python version for validation | `3.12` |
 | `CUDA_VERSION` | Expected CUDA version for validation | `12.8`, `12.9`, `13.0`, `13.1`, `13.2` |
-| `ROCM_VERSION` | Expected ROCm version for validation | `6.4` |
+| `ROCM_VERSION` | Expected ROCm version for validation | `6.4`, `7.1` |
 
 If `PYTHON_IMAGE`, `CUDA_IMAGE`, or `ROCM_IMAGE` is not set, the corresponding tests will be skipped.
 If `PYTHON_VERSION`, `CUDA_VERSION`, or `ROCM_VERSION` is not set, version validation tests will be skipped with a message.

--- a/docs/RATIONALE.md
+++ b/docs/RATIONALE.md
@@ -57,7 +57,7 @@ Provide **common base images** that ODH repositories can build upon:
 |------------|----------|
 | `Containerfile.python` | CPU workloads, web services |
 | `Containerfile.cuda` | GPU workloads, model training on NVIDIA hardware (multiple CUDA versions: 12.8, 12.9, 13.0, 13.1, 13.2) |
-| `Containerfile.rocm` | GPU workloads, model training on AMD hardware (ROCm 6.4, x86_64 only) |
+| `Containerfile.rocm` | GPU workloads, model training on AMD hardware (ROCm 6.4, 7.1, x86_64 only) |
 
 ### Benefits
 
@@ -65,7 +65,7 @@ Provide **common base images** that ODH repositories can build upon:
 |---------|-------------|
 | **Reduced duplication** | CUDA setup done once, not in every repo |
 | **Faster builds** | Downstream images skip base setup |
-| **Consistent versions** | Single source of truth for Python, CUDA, cuDNN |
+| **Consistent versions** | Single source of truth for Python, CUDA, cuDNN, ROCm |
 | **Easier upgrades** | Update base image, rebuild consumers |
 | **Security** | Centralized vulnerability management |
 | **OpenShift compatibility** | Tested patterns for restricted SCC |


### PR DESCRIPTION
PR #187 added ROCm 7.1 base image support but several documentation files were not updated. Add ROCm 7.1 references across AGENTS.md, README.md, DEVELOPMENT.md, and RATIONALE.md.

Closes #195



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ROCm 7.1 support information across documentation files
  * Updated available images table to include ROCm 7.1
  * Added ROCm 7.1 container image references and pull commands
  * Updated example Dockerfiles with ROCm 7.1 alternatives
  * Expanded test documentation with ROCm 7.1 version validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->