### PR TITLE
fix(cuda): add repo_gpgcheck=1 to CUDA yum repo config

### DIFF
--- a/Containerfile.cuda.template
+++ b/Containerfile.cuda.template
@@ -97,6 +97,7 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
       echo "baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}"; \
       echo "enabled=1"; \
       echo "gpgcheck=1"; \
+      echo "repo_gpgcheck=1"; \
       echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA"; \
     } > /etc/yum.repos.d/cuda.repo
 

--- a/cuda/12.8/Containerfile
+++ b/cuda/12.8/Containerfile
@@ -97,6 +97,7 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
       echo "baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}"; \
       echo "enabled=1"; \
       echo "gpgcheck=1"; \
+      echo "repo_gpgcheck=1"; \
       echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA"; \
     } > /etc/yum.repos.d/cuda.repo
 

--- a/cuda/12.9/Containerfile
+++ b/cuda/12.9/Containerfile
@@ -97,6 +97,7 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
       echo "baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}"; \
       echo "enabled=1"; \
       echo "gpgcheck=1"; \
+      echo "repo_gpgcheck=1"; \
       echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA"; \
     } > /etc/yum.repos.d/cuda.repo
 

--- a/cuda/13.0/Containerfile
+++ b/cuda/13.0/Containerfile
@@ -97,6 +97,7 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
       echo "baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}"; \
       echo "enabled=1"; \
       echo "gpgcheck=1"; \
+      echo "repo_gpgcheck=1"; \
       echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA"; \
     } > /etc/yum.repos.d/cuda.repo
 

--- a/cuda/13.1/Containerfile
+++ b/cuda/13.1/Containerfile
@@ -97,6 +97,7 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
       echo "baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}"; \
       echo "enabled=1"; \
       echo "gpgcheck=1"; \
+      echo "repo_gpgcheck=1"; \
       echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA"; \
     } > /etc/yum.repos.d/cuda.repo
 

--- a/cuda/13.2/Containerfile
+++ b/cuda/13.2/Containerfile
@@ -97,6 +97,7 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
       echo "baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}"; \
       echo "enabled=1"; \
       echo "gpgcheck=1"; \
+      echo "repo_gpgcheck=1"; \
       echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA"; \
     } > /etc/yum.repos.d/cuda.repo
 


### PR DESCRIPTION
Enable repository metadata signature verification (repo_gpgcheck=1) in the CUDA yum repo config to match NVIDIA's official cuda-rhel9.repo.

Fixes #158

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced GPG signature verification for CUDA repository metadata across container builds to strengthen package integrity validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->