### PR TITLE
fix: remove dnf upgrade/update for build reproducibility

### DIFF
--- a/Containerfile.cuda.template
+++ b/Containerfile.cuda.template
@@ -104,7 +104,6 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
 # CUDA Base Packages
 # -----------------------------------------------------------------------------
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
-    dnf upgrade -y --setopt=keepcache=1 && \
     dnf install -y --setopt=keepcache=1 \
         cuda-cudart-${CUDA_MAJOR_MINOR}-${NV_CUDA_CUDART_VERSION} \
         cuda-compat-${CUDA_MAJOR_MINOR}

--- a/Containerfile.python.template
+++ b/Containerfile.python.template
@@ -58,10 +58,6 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 USER 0
 
-RUN dnf update -y --setopt=tsflags=nodocs && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf /var/cache/yum
-
 # -----------------------------------------------------------------------------
 # Package Index Configuration
 # -----------------------------------------------------------------------------

--- a/Containerfile.rocm.template
+++ b/Containerfile.rocm.template
@@ -97,7 +97,6 @@ RUN if ! [ "${ROCM_MAJOR}" -eq "${ROCM_MAJOR}" ] 2>/dev/null; then \
 # ROCm Base Packages
 # -----------------------------------------------------------------------------
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
-    dnf upgrade -y --setopt=keepcache=1 && \
     dnf install -y --setopt=keepcache=1 \
         rocm-core \
         hip-runtime-amd

--- a/cuda/12.8/Containerfile
+++ b/cuda/12.8/Containerfile
@@ -104,7 +104,6 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
 # CUDA Base Packages
 # -----------------------------------------------------------------------------
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
-    dnf upgrade -y --setopt=keepcache=1 && \
     dnf install -y --setopt=keepcache=1 \
         cuda-cudart-${CUDA_MAJOR_MINOR}-${NV_CUDA_CUDART_VERSION} \
         cuda-compat-${CUDA_MAJOR_MINOR}

--- a/cuda/12.9/Containerfile
+++ b/cuda/12.9/Containerfile
@@ -104,7 +104,6 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
 # CUDA Base Packages
 # -----------------------------------------------------------------------------
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
-    dnf upgrade -y --setopt=keepcache=1 && \
     dnf install -y --setopt=keepcache=1 \
         cuda-cudart-${CUDA_MAJOR_MINOR}-${NV_CUDA_CUDART_VERSION} \
         cuda-compat-${CUDA_MAJOR_MINOR}

--- a/cuda/13.0/Containerfile
+++ b/cuda/13.0/Containerfile
@@ -104,7 +104,6 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
 # CUDA Base Packages
 # -----------------------------------------------------------------------------
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
-    dnf upgrade -y --setopt=keepcache=1 && \
     dnf install -y --setopt=keepcache=1 \
         cuda-cudart-${CUDA_MAJOR_MINOR}-${NV_CUDA_CUDART_VERSION} \
         cuda-compat-${CUDA_MAJOR_MINOR}

--- a/cuda/13.1/Containerfile
+++ b/cuda/13.1/Containerfile
@@ -104,7 +104,6 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
 # CUDA Base Packages
 # -----------------------------------------------------------------------------
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
-    dnf upgrade -y --setopt=keepcache=1 && \
     dnf install -y --setopt=keepcache=1 \
         cuda-cudart-${CUDA_MAJOR_MINOR}-${NV_CUDA_CUDART_VERSION} \
         cuda-compat-${CUDA_MAJOR_MINOR}

--- a/cuda/13.2/Containerfile
+++ b/cuda/13.2/Containerfile
@@ -104,7 +104,6 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
 # CUDA Base Packages
 # -----------------------------------------------------------------------------
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
-    dnf upgrade -y --setopt=keepcache=1 && \
     dnf install -y --setopt=keepcache=1 \
         cuda-cudart-${CUDA_MAJOR_MINOR}-${NV_CUDA_CUDART_VERSION} \
         cuda-compat-${CUDA_MAJOR_MINOR}

--- a/python/3.12/Containerfile
+++ b/python/3.12/Containerfile
@@ -58,10 +58,6 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 USER 0
 
-RUN dnf update -y --setopt=tsflags=nodocs && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf /var/cache/yum
-
 # -----------------------------------------------------------------------------
 # Package Index Configuration
 # -----------------------------------------------------------------------------

--- a/rocm/6.4/Containerfile
+++ b/rocm/6.4/Containerfile
@@ -97,7 +97,6 @@ RUN if ! [ "${ROCM_MAJOR}" -eq "${ROCM_MAJOR}" ] 2>/dev/null; then \
 # ROCm Base Packages
 # -----------------------------------------------------------------------------
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
-    dnf upgrade -y --setopt=keepcache=1 && \
     dnf install -y --setopt=keepcache=1 \
         rocm-core \
         hip-runtime-amd

--- a/rocm/7.1/Containerfile
+++ b/rocm/7.1/Containerfile
@@ -97,7 +97,6 @@ RUN if ! [ "${ROCM_MAJOR}" -eq "${ROCM_MAJOR}" ] 2>/dev/null; then \
 # ROCm Base Packages
 # -----------------------------------------------------------------------------
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
-    dnf upgrade -y --setopt=keepcache=1 && \
     dnf install -y --setopt=keepcache=1 \
         rocm-core \
         hip-runtime-amd


### PR DESCRIPTION
Remove `dnf upgrade -y` from CUDA and ROCm templates and `dnf update -y` from the Python template. These commands pull whatever OS packages are available at build time, so the same commit produces different images on different days.

Security patches are already handled by Renovate, which auto-bumps the pinned base image digest in app.conf when upstream publishes new images.

Closes #159

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized container build processes by removing redundant package upgrade steps from CUDA, ROCm, and Python image definitions across multiple versions. This streamlines build time and reduces unnecessary system updates during image construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->