### PR TITLE
fix(build): add --require-hashes to pip install for build-time deps

### DIFF
--- a/Containerfile.cuda.template
+++ b/Containerfile.cuda.template
@@ -205,7 +205,7 @@ RUN mkdir -p /etc/pip && \
 # https://github.com/astral-sh/uv
 # Version pinned in requirements-build.txt
 COPY --chmod=644 --chown=0:0 requirements-build.txt /tmp/requirements-build.txt
-RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
+RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)

--- a/Containerfile.python.template
+++ b/Containerfile.python.template
@@ -84,7 +84,7 @@ RUN mkdir -p /etc/pip && \
 # https://github.com/astral-sh/uv
 # Version pinned in requirements-build.txt
 COPY --chmod=644 --chown=0:0 requirements-build.txt /tmp/requirements-build.txt
-RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
+RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)

--- a/Containerfile.rocm.template
+++ b/Containerfile.rocm.template
@@ -184,7 +184,7 @@ RUN mkdir -p /etc/pip && \
 # https://github.com/astral-sh/uv
 # Version pinned in requirements-build.txt
 COPY --chmod=644 --chown=0:0 requirements-build.txt /tmp/requirements-build.txt
-RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
+RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)

--- a/cuda/12.8/Containerfile
+++ b/cuda/12.8/Containerfile
@@ -205,7 +205,7 @@ RUN mkdir -p /etc/pip && \
 # https://github.com/astral-sh/uv
 # Version pinned in requirements-build.txt
 COPY --chmod=644 --chown=0:0 requirements-build.txt /tmp/requirements-build.txt
-RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
+RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)

--- a/cuda/12.9/Containerfile
+++ b/cuda/12.9/Containerfile
@@ -205,7 +205,7 @@ RUN mkdir -p /etc/pip && \
 # https://github.com/astral-sh/uv
 # Version pinned in requirements-build.txt
 COPY --chmod=644 --chown=0:0 requirements-build.txt /tmp/requirements-build.txt
-RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
+RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)

--- a/cuda/13.0/Containerfile
+++ b/cuda/13.0/Containerfile
@@ -205,7 +205,7 @@ RUN mkdir -p /etc/pip && \
 # https://github.com/astral-sh/uv
 # Version pinned in requirements-build.txt
 COPY --chmod=644 --chown=0:0 requirements-build.txt /tmp/requirements-build.txt
-RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
+RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)

--- a/cuda/13.1/Containerfile
+++ b/cuda/13.1/Containerfile
@@ -205,7 +205,7 @@ RUN mkdir -p /etc/pip && \
 # https://github.com/astral-sh/uv
 # Version pinned in requirements-build.txt
 COPY --chmod=644 --chown=0:0 requirements-build.txt /tmp/requirements-build.txt
-RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
+RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)

--- a/cuda/13.2/Containerfile
+++ b/cuda/13.2/Containerfile
@@ -205,7 +205,7 @@ RUN mkdir -p /etc/pip && \
 # https://github.com/astral-sh/uv
 # Version pinned in requirements-build.txt
 COPY --chmod=644 --chown=0:0 requirements-build.txt /tmp/requirements-build.txt
-RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
+RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)

--- a/python/3.12/Containerfile
+++ b/python/3.12/Containerfile
@@ -84,7 +84,7 @@ RUN mkdir -p /etc/pip && \
 # https://github.com/astral-sh/uv
 # Version pinned in requirements-build.txt
 COPY --chmod=644 --chown=0:0 requirements-build.txt /tmp/requirements-build.txt
-RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
+RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,6 +1,27 @@
 # Build-time Python dependencies
 # These are installed during container image build, not at runtime.
-# Dependabot/Renovate can automatically update these versions.
+# Dependabot/Renovate can automatically update these versions and hashes.
+#
+# Hashes from PyPI: https://pypi.org/pypi/uv/0.11.7/json
+# All platform wheels are listed so --require-hashes works on any arch.
 
-uv==0.11.7
-
+uv==0.11.7 \
+    --hash=sha256:f422d39530516b1dfb28bb6e90c32bb7dacd50f6a383cd6e40c1a859419fbc8c \
+    --hash=sha256:8b2fe1ec6775dad10183e3fdce430a5b37b7857d49763c884f3a67eaa8ca6f8a \
+    --hash=sha256:162fa961a9a081dcea6e889c79f738a5ae56507047e4672964972e33c301bea9 \
+    --hash=sha256:5985a15a92bd9a170fc1947abb1fbc3e9828c5a430ad85b5bed8356c20b67a71 \
+    --hash=sha256:fab0bb43fbbc0ee5b5fee212078d2300c371b725faff7cf72eeaafa0bff0606b \
+    --hash=sha256:23d457d6731ebdb83f1bffebe4894edab2ef43c1ec5488433c74300db4958924 \
+    --hash=sha256:7d6a17507b8139b8803f445a03fd097f732ce8356b1b7b13cdb4dd8ef7f4b2e0 \
+    --hash=sha256:dd48823ca4b505124389f49ae50626ba9f57212b9047738efc95126ed5f3844d \
+    --hash=sha256:eb91f52ee67e10d5290f2c2897e2171357f1a10966de38d83eefa93d96843b0c \
+    --hash=sha256:4e4d5e31bea86e1b6e0f5a0f95e14e80018e6f6c0129256d2915a4b3d793644d \
+    --hash=sha256:ceae53b202ea92bc954759bc7c7570cdcd5c3512fce15701198c19fd2dfb8605 \
+    --hash=sha256:f97e9f4e4d44fb5c4dfaa05e858ef3414a96416a2e4af270ecd88a3e5fb049a9 \
+    --hash=sha256:750ee5b96959b807cf442b73dd8b55111862d63f258f896787ea5f06b68aaca9 \
+    --hash=sha256:f394331f0507e80ee732cb3df737589de53bed999dd02a6d24682f08c2f8ac4f \
+    --hash=sha256:0df59ab0c6a4b14a763e8445e1c303af9abeb53cdfa4428daf9ff9642c0a3cce \
+    --hash=sha256:553e67cc766d013ce24353fecd4ea5533d2aedcfd35f9fac430e07b1d1f23ed4 \
+    --hash=sha256:5674dfb5944513f4b3735b05c2deba6b1b01151f46729d533d413a9a905f8c5d \
+    --hash=sha256:6158b7e39464f1aa1e040daa0186cae4749a78b5cd80ac769f32ca711b8976b1 \
+    --hash=sha256:46d971489b00bdb27e0aa715e4a5cd4ef2c28ea5b6ef78f2b67bf861eb44b405

--- a/rocm/6.4/Containerfile
+++ b/rocm/6.4/Containerfile
@@ -184,7 +184,7 @@ RUN mkdir -p /etc/pip && \
 # https://github.com/astral-sh/uv
 # Version pinned in requirements-build.txt
 COPY --chmod=644 --chown=0:0 requirements-build.txt /tmp/requirements-build.txt
-RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
+RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)

--- a/rocm/7.1/Containerfile
+++ b/rocm/7.1/Containerfile
@@ -184,7 +184,7 @@ RUN mkdir -p /etc/pip && \
 # https://github.com/astral-sh/uv
 # Version pinned in requirements-build.txt
 COPY --chmod=644 --chown=0:0 requirements-build.txt /tmp/requirements-build.txt
-RUN python -m pip install --no-cache-dir -r /tmp/requirements-build.txt && \
+RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-build.txt && \
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)


### PR DESCRIPTION
Add SHA-256 hash verification to requirements-build.txt and pass --require-hashes to pip install in all Containerfile templates and generated Containerfiles. This prevents substitution of tampered packages via compromised mirrors by verifying downloaded wheels against known-good checksums from PyPI.

Hashes cover all platform wheels so multi-arch builds (amd64/arm64) work correctly. Renovate natively supports updating hashes when bumping versions.

Closes: #160

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency installation validation for all container images. Python dependencies are now installed with enforced SHA256 hash verification to ensure installation consistency across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->