### PR TITLE
Pin unpinned CUDA packages for reproducible builds (#162)

### DIFF
--- a/Containerfile.cuda.template
+++ b/Containerfile.cuda.template
@@ -19,7 +19,10 @@ ARG NV_LIBNPP_VERSION
 ARG NV_LIBCUBLAS_VERSION
 ARG NV_LIBNCCL_VERSION
 ARG NV_LIBNCCL_PACKAGE_VERSION
+ARG NV_CUDA_CUPTI_VERSION
 ARG NV_CUDNN_VERSION
+ARG NV_LIBCUSPARSELT_VERSION
+ARG NV_LIBCUDSS_VERSION
 ARG NVIDIA_REQUIRE_CUDA
 
 # Build metadata for OCI labels
@@ -54,7 +57,10 @@ ARG NV_LIBNPP_VERSION
 ARG NV_LIBCUBLAS_VERSION
 ARG NV_LIBNCCL_VERSION
 ARG NV_LIBNCCL_PACKAGE_VERSION
+ARG NV_CUDA_CUPTI_VERSION
 ARG NV_CUDNN_VERSION
+ARG NV_LIBCUSPARSELT_VERSION
+ARG NV_LIBCUDSS_VERSION
 
 USER 0
 WORKDIR /opt/app-root/bin
@@ -103,6 +109,10 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
 # -----------------------------------------------------------------------------
 # CUDA Base Packages
 # -----------------------------------------------------------------------------
+# cuda-compat is intentionally unpinned: provides forward-compatible userspace
+# CUDA libraries so containers work with newer host GPU drivers. NVIDIA leaves
+# this unpinned by design in their own images.
+# https://docs.nvidia.com/deploy/cuda-compatibility/
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
     dnf upgrade -y --setopt=keepcache=1 && \
     dnf install -y --setopt=keepcache=1 \
@@ -158,9 +168,9 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containe
 # -----------------------------------------------------------------------------
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
     dnf install -y --setopt=keepcache=1 \
-        cuda-cupti-${CUDA_MAJOR_MINOR} \
-        libcusparselt0 \
-        libcudss0-cuda-${CUDA_MAJOR}
+        cuda-cupti-${CUDA_MAJOR_MINOR}-${NV_CUDA_CUPTI_VERSION} \
+        libcusparselt0-${NV_LIBCUSPARSELT_VERSION} \
+        libcudss0-cuda-${CUDA_MAJOR}-${NV_LIBCUDSS_VERSION}
 
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 

--- a/cuda/12.8/Containerfile
+++ b/cuda/12.8/Containerfile
@@ -19,7 +19,10 @@ ARG NV_LIBNPP_VERSION
 ARG NV_LIBCUBLAS_VERSION
 ARG NV_LIBNCCL_VERSION
 ARG NV_LIBNCCL_PACKAGE_VERSION
+ARG NV_CUDA_CUPTI_VERSION
 ARG NV_CUDNN_VERSION
+ARG NV_LIBCUSPARSELT_VERSION
+ARG NV_LIBCUDSS_VERSION
 ARG NVIDIA_REQUIRE_CUDA
 
 # Build metadata for OCI labels
@@ -54,7 +57,10 @@ ARG NV_LIBNPP_VERSION
 ARG NV_LIBCUBLAS_VERSION
 ARG NV_LIBNCCL_VERSION
 ARG NV_LIBNCCL_PACKAGE_VERSION
+ARG NV_CUDA_CUPTI_VERSION
 ARG NV_CUDNN_VERSION
+ARG NV_LIBCUSPARSELT_VERSION
+ARG NV_LIBCUDSS_VERSION
 
 USER 0
 WORKDIR /opt/app-root/bin
@@ -103,6 +109,10 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
 # -----------------------------------------------------------------------------
 # CUDA Base Packages
 # -----------------------------------------------------------------------------
+# cuda-compat is intentionally unpinned: provides forward-compatible userspace
+# CUDA libraries so containers work with newer host GPU drivers. NVIDIA leaves
+# this unpinned by design in their own images.
+# https://docs.nvidia.com/deploy/cuda-compatibility/
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
     dnf upgrade -y --setopt=keepcache=1 && \
     dnf install -y --setopt=keepcache=1 \
@@ -158,9 +168,9 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containe
 # -----------------------------------------------------------------------------
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
     dnf install -y --setopt=keepcache=1 \
-        cuda-cupti-${CUDA_MAJOR_MINOR} \
-        libcusparselt0 \
-        libcudss0-cuda-${CUDA_MAJOR}
+        cuda-cupti-${CUDA_MAJOR_MINOR}-${NV_CUDA_CUPTI_VERSION} \
+        libcusparselt0-${NV_LIBCUSPARSELT_VERSION} \
+        libcudss0-cuda-${CUDA_MAJOR}-${NV_LIBCUDSS_VERSION}
 
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 

--- a/cuda/12.8/app.conf
+++ b/cuda/12.8/app.conf
@@ -73,6 +73,27 @@ NV_LIBNCCL_PACKAGE_VERSION=2.25.1-1
 NV_CUDNN_VERSION=9.8.0.87-1
 
 # -----------------------------------------------------------------------------
+# CUPTI (CUDA Profiling Tools Interface)
+# Required by PyTorch profiler; not present in NVIDIA images (ODH-specific).
+# Source: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+NV_CUDA_CUPTI_VERSION=12.8.90-1
+
+# -----------------------------------------------------------------------------
+# cuSPARSELt (structured sparsity)
+# Required by PyTorch sparse operations; not present in NVIDIA images (ODH-specific).
+# Source: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+NV_LIBCUSPARSELT_VERSION=0.7.1.0-1
+
+# -----------------------------------------------------------------------------
+# cuDSS (direct sparse solver)
+# Required by scientific/ML solvers; not present in NVIDIA images (ODH-specific).
+# Source: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+NV_LIBCUDSS_VERSION=0.7.1.4-1
+
+# -----------------------------------------------------------------------------
 # PyPI Indexes
 # -----------------------------------------------------------------------------
 PIP_INDEX_URL=https://pypi.org/simple

--- a/cuda/12.9/Containerfile
+++ b/cuda/12.9/Containerfile
@@ -19,7 +19,10 @@ ARG NV_LIBNPP_VERSION
 ARG NV_LIBCUBLAS_VERSION
 ARG NV_LIBNCCL_VERSION
 ARG NV_LIBNCCL_PACKAGE_VERSION
+ARG NV_CUDA_CUPTI_VERSION
 ARG NV_CUDNN_VERSION
+ARG NV_LIBCUSPARSELT_VERSION
+ARG NV_LIBCUDSS_VERSION
 ARG NVIDIA_REQUIRE_CUDA
 
 # Build metadata for OCI labels
@@ -54,7 +57,10 @@ ARG NV_LIBNPP_VERSION
 ARG NV_LIBCUBLAS_VERSION
 ARG NV_LIBNCCL_VERSION
 ARG NV_LIBNCCL_PACKAGE_VERSION
+ARG NV_CUDA_CUPTI_VERSION
 ARG NV_CUDNN_VERSION
+ARG NV_LIBCUSPARSELT_VERSION
+ARG NV_LIBCUDSS_VERSION
 
 USER 0
 WORKDIR /opt/app-root/bin
@@ -103,6 +109,10 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
 # -----------------------------------------------------------------------------
 # CUDA Base Packages
 # -----------------------------------------------------------------------------
+# cuda-compat is intentionally unpinned: provides forward-compatible userspace
+# CUDA libraries so containers work with newer host GPU drivers. NVIDIA leaves
+# this unpinned by design in their own images.
+# https://docs.nvidia.com/deploy/cuda-compatibility/
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
     dnf upgrade -y --setopt=keepcache=1 && \
     dnf install -y --setopt=keepcache=1 \
@@ -158,9 +168,9 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containe
 # -----------------------------------------------------------------------------
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
     dnf install -y --setopt=keepcache=1 \
-        cuda-cupti-${CUDA_MAJOR_MINOR} \
-        libcusparselt0 \
-        libcudss0-cuda-${CUDA_MAJOR}
+        cuda-cupti-${CUDA_MAJOR_MINOR}-${NV_CUDA_CUPTI_VERSION} \
+        libcusparselt0-${NV_LIBCUSPARSELT_VERSION} \
+        libcudss0-cuda-${CUDA_MAJOR}-${NV_LIBCUDSS_VERSION}
 
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 

--- a/cuda/12.9/app.conf
+++ b/cuda/12.9/app.conf
@@ -73,6 +73,27 @@ NV_LIBNCCL_PACKAGE_VERSION=2.27.3-1
 NV_CUDNN_VERSION=9.8.0.87-1
 
 # -----------------------------------------------------------------------------
+# CUPTI (CUDA Profiling Tools Interface)
+# Required by PyTorch profiler; not present in NVIDIA images (ODH-specific).
+# Source: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+NV_CUDA_CUPTI_VERSION=12.9.79-1
+
+# -----------------------------------------------------------------------------
+# cuSPARSELt (structured sparsity)
+# Required by PyTorch sparse operations; not present in NVIDIA images (ODH-specific).
+# Source: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+NV_LIBCUSPARSELT_VERSION=0.7.1.0-1
+
+# -----------------------------------------------------------------------------
+# cuDSS (direct sparse solver)
+# Required by scientific/ML solvers; not present in NVIDIA images (ODH-specific).
+# Source: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+NV_LIBCUDSS_VERSION=0.7.1.4-1
+
+# -----------------------------------------------------------------------------
 # PyPI Indexes
 # Note: PyTorch does not publish cu129 wheels. Using cu128 instead, which is
 # compatible because CUDA minor versions are backwards-compatible within the

--- a/cuda/13.0/Containerfile
+++ b/cuda/13.0/Containerfile
@@ -19,7 +19,10 @@ ARG NV_LIBNPP_VERSION
 ARG NV_LIBCUBLAS_VERSION
 ARG NV_LIBNCCL_VERSION
 ARG NV_LIBNCCL_PACKAGE_VERSION
+ARG NV_CUDA_CUPTI_VERSION
 ARG NV_CUDNN_VERSION
+ARG NV_LIBCUSPARSELT_VERSION
+ARG NV_LIBCUDSS_VERSION
 ARG NVIDIA_REQUIRE_CUDA
 
 # Build metadata for OCI labels
@@ -54,7 +57,10 @@ ARG NV_LIBNPP_VERSION
 ARG NV_LIBCUBLAS_VERSION
 ARG NV_LIBNCCL_VERSION
 ARG NV_LIBNCCL_PACKAGE_VERSION
+ARG NV_CUDA_CUPTI_VERSION
 ARG NV_CUDNN_VERSION
+ARG NV_LIBCUSPARSELT_VERSION
+ARG NV_LIBCUDSS_VERSION
 
 USER 0
 WORKDIR /opt/app-root/bin
@@ -103,6 +109,10 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
 # -----------------------------------------------------------------------------
 # CUDA Base Packages
 # -----------------------------------------------------------------------------
+# cuda-compat is intentionally unpinned: provides forward-compatible userspace
+# CUDA libraries so containers work with newer host GPU drivers. NVIDIA leaves
+# this unpinned by design in their own images.
+# https://docs.nvidia.com/deploy/cuda-compatibility/
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
     dnf upgrade -y --setopt=keepcache=1 && \
     dnf install -y --setopt=keepcache=1 \
@@ -158,9 +168,9 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containe
 # -----------------------------------------------------------------------------
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
     dnf install -y --setopt=keepcache=1 \
-        cuda-cupti-${CUDA_MAJOR_MINOR} \
-        libcusparselt0 \
-        libcudss0-cuda-${CUDA_MAJOR}
+        cuda-cupti-${CUDA_MAJOR_MINOR}-${NV_CUDA_CUPTI_VERSION} \
+        libcusparselt0-${NV_LIBCUSPARSELT_VERSION} \
+        libcudss0-cuda-${CUDA_MAJOR}-${NV_LIBCUDSS_VERSION}
 
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 

--- a/cuda/13.0/app.conf
+++ b/cuda/13.0/app.conf
@@ -73,6 +73,27 @@ NV_LIBNCCL_PACKAGE_VERSION=2.28.3-1
 NV_CUDNN_VERSION=9.15.1.9-1
 
 # -----------------------------------------------------------------------------
+# CUPTI (CUDA Profiling Tools Interface)
+# Required by PyTorch profiler; not present in NVIDIA images (ODH-specific).
+# Source: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+NV_CUDA_CUPTI_VERSION=13.0.85-1
+
+# -----------------------------------------------------------------------------
+# cuSPARSELt (structured sparsity)
+# Required by PyTorch sparse operations; not present in NVIDIA images (ODH-specific).
+# Source: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+NV_LIBCUSPARSELT_VERSION=0.7.1.0-1
+
+# -----------------------------------------------------------------------------
+# cuDSS (direct sparse solver)
+# Required by scientific/ML solvers; not present in NVIDIA images (ODH-specific).
+# Source: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+NV_LIBCUDSS_VERSION=0.7.1.4-1
+
+# -----------------------------------------------------------------------------
 # PyPI Indexes
 # -----------------------------------------------------------------------------
 PIP_INDEX_URL=https://pypi.org/simple

--- a/cuda/13.1/Containerfile
+++ b/cuda/13.1/Containerfile
@@ -19,7 +19,10 @@ ARG NV_LIBNPP_VERSION
 ARG NV_LIBCUBLAS_VERSION
 ARG NV_LIBNCCL_VERSION
 ARG NV_LIBNCCL_PACKAGE_VERSION
+ARG NV_CUDA_CUPTI_VERSION
 ARG NV_CUDNN_VERSION
+ARG NV_LIBCUSPARSELT_VERSION
+ARG NV_LIBCUDSS_VERSION
 ARG NVIDIA_REQUIRE_CUDA
 
 # Build metadata for OCI labels
@@ -54,7 +57,10 @@ ARG NV_LIBNPP_VERSION
 ARG NV_LIBCUBLAS_VERSION
 ARG NV_LIBNCCL_VERSION
 ARG NV_LIBNCCL_PACKAGE_VERSION
+ARG NV_CUDA_CUPTI_VERSION
 ARG NV_CUDNN_VERSION
+ARG NV_LIBCUSPARSELT_VERSION
+ARG NV_LIBCUDSS_VERSION
 
 USER 0
 WORKDIR /opt/app-root/bin
@@ -103,6 +109,10 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
 # -----------------------------------------------------------------------------
 # CUDA Base Packages
 # -----------------------------------------------------------------------------
+# cuda-compat is intentionally unpinned: provides forward-compatible userspace
+# CUDA libraries so containers work with newer host GPU drivers. NVIDIA leaves
+# this unpinned by design in their own images.
+# https://docs.nvidia.com/deploy/cuda-compatibility/
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
     dnf upgrade -y --setopt=keepcache=1 && \
     dnf install -y --setopt=keepcache=1 \
@@ -158,9 +168,9 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containe
 # -----------------------------------------------------------------------------
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
     dnf install -y --setopt=keepcache=1 \
-        cuda-cupti-${CUDA_MAJOR_MINOR} \
-        libcusparselt0 \
-        libcudss0-cuda-${CUDA_MAJOR}
+        cuda-cupti-${CUDA_MAJOR_MINOR}-${NV_CUDA_CUPTI_VERSION} \
+        libcusparselt0-${NV_LIBCUSPARSELT_VERSION} \
+        libcudss0-cuda-${CUDA_MAJOR}-${NV_LIBCUDSS_VERSION}
 
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 

--- a/cuda/13.1/app.conf
+++ b/cuda/13.1/app.conf
@@ -73,6 +73,27 @@ NV_LIBNCCL_PACKAGE_VERSION=2.29.2-1
 NV_CUDNN_VERSION=9.17.1.4-1
 
 # -----------------------------------------------------------------------------
+# CUPTI (CUDA Profiling Tools Interface)
+# Required by PyTorch profiler; not present in NVIDIA images (ODH-specific).
+# Source: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+NV_CUDA_CUPTI_VERSION=13.1.115-1
+
+# -----------------------------------------------------------------------------
+# cuSPARSELt (structured sparsity)
+# Required by PyTorch sparse operations; not present in NVIDIA images (ODH-specific).
+# Source: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+NV_LIBCUSPARSELT_VERSION=0.7.1.0-1
+
+# -----------------------------------------------------------------------------
+# cuDSS (direct sparse solver)
+# Required by scientific/ML solvers; not present in NVIDIA images (ODH-specific).
+# Source: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+NV_LIBCUDSS_VERSION=0.7.1.4-1
+
+# -----------------------------------------------------------------------------
 # PyPI Indexes
 # Note: Using cu130 for CUDA 13.1 - PyTorch doesn't publish cu131 wheels.
 # CUDA minor versions within the same major are compatible.

--- a/cuda/13.2/Containerfile
+++ b/cuda/13.2/Containerfile
@@ -19,7 +19,10 @@ ARG NV_LIBNPP_VERSION
 ARG NV_LIBCUBLAS_VERSION
 ARG NV_LIBNCCL_VERSION
 ARG NV_LIBNCCL_PACKAGE_VERSION
+ARG NV_CUDA_CUPTI_VERSION
 ARG NV_CUDNN_VERSION
+ARG NV_LIBCUSPARSELT_VERSION
+ARG NV_LIBCUDSS_VERSION
 ARG NVIDIA_REQUIRE_CUDA
 
 # Build metadata for OCI labels
@@ -54,7 +57,10 @@ ARG NV_LIBNPP_VERSION
 ARG NV_LIBCUBLAS_VERSION
 ARG NV_LIBNCCL_VERSION
 ARG NV_LIBNCCL_PACKAGE_VERSION
+ARG NV_CUDA_CUPTI_VERSION
 ARG NV_CUDNN_VERSION
+ARG NV_LIBCUSPARSELT_VERSION
+ARG NV_LIBCUDSS_VERSION
 
 USER 0
 WORKDIR /opt/app-root/bin
@@ -103,6 +109,10 @@ RUN { echo "[cuda-rhel9-${NVARCH}]"; \
 # -----------------------------------------------------------------------------
 # CUDA Base Packages
 # -----------------------------------------------------------------------------
+# cuda-compat is intentionally unpinned: provides forward-compatible userspace
+# CUDA libraries so containers work with newer host GPU drivers. NVIDIA leaves
+# this unpinned by design in their own images.
+# https://docs.nvidia.com/deploy/cuda-compatibility/
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
     dnf upgrade -y --setopt=keepcache=1 && \
     dnf install -y --setopt=keepcache=1 \
@@ -158,9 +168,9 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containe
 # -----------------------------------------------------------------------------
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-cuda-dnf \
     dnf install -y --setopt=keepcache=1 \
-        cuda-cupti-${CUDA_MAJOR_MINOR} \
-        libcusparselt0 \
-        libcudss0-cuda-${CUDA_MAJOR}
+        cuda-cupti-${CUDA_MAJOR_MINOR}-${NV_CUDA_CUPTI_VERSION} \
+        libcusparselt0-${NV_LIBCUSPARSELT_VERSION} \
+        libcudss0-cuda-${CUDA_MAJOR}-${NV_LIBCUDSS_VERSION}
 
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 

--- a/cuda/13.2/app.conf
+++ b/cuda/13.2/app.conf
@@ -73,6 +73,27 @@ NV_LIBNCCL_PACKAGE_VERSION=2.29.7-1
 NV_CUDNN_VERSION=9.20.0.48-1
 
 # -----------------------------------------------------------------------------
+# CUPTI (CUDA Profiling Tools Interface)
+# Required by PyTorch profiler; not present in NVIDIA images (ODH-specific).
+# Source: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+NV_CUDA_CUPTI_VERSION=13.2.75-1
+
+# -----------------------------------------------------------------------------
+# cuSPARSELt (structured sparsity)
+# Required by PyTorch sparse operations; not present in NVIDIA images (ODH-specific).
+# Source: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+NV_LIBCUSPARSELT_VERSION=0.7.1.0-1
+
+# -----------------------------------------------------------------------------
+# cuDSS (direct sparse solver)
+# Required by scientific/ML solvers; not present in NVIDIA images (ODH-specific).
+# Source: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+NV_LIBCUDSS_VERSION=0.7.1.4-1
+
+# -----------------------------------------------------------------------------
 # PyPI Indexes
 # Note: Using cu130 for CUDA 13.2 - PyTorch doesn't publish cu132 wheels.
 # CUDA minor versions within the same major are compatible.

--- a/scripts/generate-containerfile.sh
+++ b/scripts/generate-containerfile.sh
@@ -248,6 +248,9 @@ create_cuda_appconf() {
         NV_LIBNCCL_VERSION
         NV_LIBNCCL_PACKAGE_VERSION
         NV_CUDNN_VERSION
+        NV_CUDA_CUPTI_VERSION
+        NV_LIBCUSPARSELT_VERSION
+        NV_LIBCUDSS_VERSION
     )
     for key in "${nvidia_keys[@]}"; do
         # Add TODO comment before each NVIDIA-specific key (if not already present)


### PR DESCRIPTION
Pin cuda-cupti, libcusparselt0, and libcudss0 with explicit versions
sourced from NVIDIA's RPM repository. These ODH-specific packages were
previously installed without version pins, making builds non-reproducible.

- Add NV_CUDA_CUPTI_VERSION, NV_LIBCUSPARSELT_VERSION, NV_LIBCUDSS_VERSION
  build args to template and all 5 app.conf files (12.8–13.2)
cuda-toolkit meta-package is left as-is; replacing it with granular
packages requires a dependency audit and should be a separate issue.

Closes #162 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CUDA container build configuration across versions 12.8–13.2 to enable precise versioning of CUPTI, cuSPARSELt, and cuDSS libraries, resulting in more reproducible and consistent container image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->