### PR TITLE
Add pull request template with testing checklist (#139)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## What
+<!-- Brief description of the change -->
+
+
+## Why
+<!-- Link to issue or motivation -->
+
+Closes #
+
+## Checklist
+<!-- Check items that apply. Strike through items that don't apply to this PR: ~[ ]~ -->
+
+### All PRs
+- [ ] Linting, formatting, and type checks pass (`tox -e lint`, `tox -e type`)
+- [ ] Tests added/updated where applicable (`tox -e test`)
+
+### Containerfile / image changes
+- [ ] Edited the `Containerfile.*.template`, not version-specific `<type>/<version>/Containerfile` directly
+- [ ] Regenerated version-specific Containerfiles (`./scripts/generate-containerfile.sh`)
+- [ ] Containerfile linting passes (`./scripts/lint-containerfile.sh`)
+- [ ] Versions and URLs are in `app.conf` build args, not hardcoded
+- [ ] Image builds successfully (`./scripts/build.sh <type>-<version>`)
+- [ ] No `:latest` tags or root (UID 0) user in container images


### PR DESCRIPTION
Add .github/PULL_REQUEST_TEMPLATE.md with What/Why sections and a checklist covering signed commits, linting (ruff + Hadolint), template editing workflow, and container image standards. Checklist is split into items that apply to all PRs vs. Containerfile-specific changes.

Closes #139


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a GitHub pull request template prompting a concise change description and issue linkage, and enforcing quality checklists (lint/format/type checks and tests). Includes a container/image checklist requiring edits to canonical container templates and regeneration via the generator, containerfile linting, use of build args for versions/URLs (no hardcoded values), successful image builds, prohibition of `:latest` tags, and disallowing root (UID 0) users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->