### PR TITLE
Bump step-level resource overrides across all pipelines

### DIFF
--- a/.tekton/odh-midstream-cuda-base-12-8-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-8-pull-request.yaml
@@ -53,6 +53,22 @@ spec:
               memory: 4Gi
             limits:
               memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-12-8-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-8-pull-request.yaml
@@ -45,6 +45,14 @@ spec:
   pipelineRef:
     name: odh-base-containers-pull-request
   taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-12-8-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-8-push.yaml
@@ -50,6 +50,22 @@ spec:
               memory: 4Gi
             limits:
               memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-12-8-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-8-push.yaml
@@ -42,6 +42,14 @@ spec:
   pipelineRef:
     name: odh-base-containers-push
   taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-12-9-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-9-pull-request.yaml
@@ -53,6 +53,22 @@ spec:
               memory: 4Gi
             limits:
               memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-12-9-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-9-pull-request.yaml
@@ -45,6 +45,14 @@ spec:
   pipelineRef:
     name: odh-base-containers-pull-request
   taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-12-9-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-9-push.yaml
@@ -50,6 +50,22 @@ spec:
               memory: 4Gi
             limits:
               memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-12-9-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-9-push.yaml
@@ -42,6 +42,14 @@ spec:
   pipelineRef:
     name: odh-base-containers-push
   taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-0-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-0-pull-request.yaml
@@ -53,6 +53,22 @@ spec:
               memory: 4Gi
             limits:
               memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-0-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-0-pull-request.yaml
@@ -45,6 +45,14 @@ spec:
   pipelineRef:
     name: odh-base-containers-pull-request
   taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-0-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-0-push.yaml
@@ -50,6 +50,22 @@ spec:
               memory: 4Gi
             limits:
               memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-0-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-0-push.yaml
@@ -42,6 +42,14 @@ spec:
   pipelineRef:
     name: odh-base-containers-push
   taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-1-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-1-pull-request.yaml
@@ -53,6 +53,22 @@ spec:
               memory: 4Gi
             limits:
               memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-1-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-1-pull-request.yaml
@@ -45,6 +45,14 @@ spec:
   pipelineRef:
     name: odh-base-containers-pull-request
   taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-1-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-1-push.yaml
@@ -50,6 +50,22 @@ spec:
               memory: 4Gi
             limits:
               memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-1-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-1-push.yaml
@@ -42,6 +42,14 @@ spec:
   pipelineRef:
     name: odh-base-containers-push
   taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-2-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-2-pull-request.yaml
@@ -53,6 +53,22 @@ spec:
               memory: 4Gi
             limits:
               memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-2-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-2-pull-request.yaml
@@ -45,6 +45,14 @@ spec:
   pipelineRef:
     name: odh-base-containers-pull-request
   taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-2-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-2-push.yaml
@@ -50,6 +50,22 @@ spec:
               memory: 4Gi
             limits:
               memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-2-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-2-push.yaml
@@ -42,6 +42,14 @@ spec:
   pipelineRef:
     name: odh-base-containers-push
   taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-python-base-3-12-pull-request.yaml
+++ b/.tekton/odh-midstream-python-base-3-12-pull-request.yaml
@@ -44,6 +44,39 @@ spec:
     value: python/3.12/app.conf
   pipelineRef:
     name: odh-base-containers-pull-request
+  taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      stepSpecs:
+        - name: app-check
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-midstream-python-base-3-12
   workspaces:

--- a/.tekton/odh-midstream-python-base-3-12-push.yaml
+++ b/.tekton/odh-midstream-python-base-3-12-push.yaml
@@ -41,6 +41,39 @@ spec:
     value: python/3.12/app.conf
   pipelineRef:
     name: odh-base-containers-push
+  taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      stepSpecs:
+        - name: app-check
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-midstream-python-base-3-12
   workspaces:

--- a/.tekton/odh-midstream-rocm-base-6-4-pull-request.yaml
+++ b/.tekton/odh-midstream-rocm-base-6-4-pull-request.yaml
@@ -45,20 +45,6 @@ spec:
   pipelineRef:
     name: odh-base-containers-pull-request
   taskRunSpecs:
-    - pipelineTaskName: clair-scan
-      stepSpecs:
-        - name: get-vulnerabilities
-          computeResources:
-            requests:
-              memory: 4Gi
-            limits:
-              memory: 8Gi
-        - name: oci-attach-report
-          computeResources:
-            requests:
-              memory: 4Gi
-            limits:
-              memory: 8Gi
     - pipelineTaskName: clamav-scan
       stepSpecs:
         - name: extract-and-scan-image
@@ -67,6 +53,22 @@ spec:
               memory: 4Gi
             limits:
               memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-rocm-base-6-4-pull-request.yaml
+++ b/.tekton/odh-midstream-rocm-base-6-4-pull-request.yaml
@@ -59,6 +59,14 @@ spec:
               memory: 4Gi
             limits:
               memory: 8Gi
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-rocm-base-6-4-push.yaml
+++ b/.tekton/odh-midstream-rocm-base-6-4-push.yaml
@@ -42,20 +42,6 @@ spec:
   pipelineRef:
     name: odh-base-containers-push
   taskRunSpecs:
-    - pipelineTaskName: clair-scan
-      stepSpecs:
-        - name: get-vulnerabilities
-          computeResources:
-            requests:
-              memory: 4Gi
-            limits:
-              memory: 8Gi
-        - name: oci-attach-report
-          computeResources:
-            requests:
-              memory: 4Gi
-            limits:
-              memory: 8Gi
     - pipelineTaskName: clamav-scan
       stepSpecs:
         - name: extract-and-scan-image
@@ -64,6 +50,22 @@ spec:
               memory: 4Gi
             limits:
               memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-rocm-base-6-4-push.yaml
+++ b/.tekton/odh-midstream-rocm-base-6-4-push.yaml
@@ -56,6 +56,14 @@ spec:
               memory: 4Gi
             limits:
               memory: 8Gi
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-rocm-base-7-1-pull-request.yaml
+++ b/.tekton/odh-midstream-rocm-base-7-1-pull-request.yaml
@@ -45,20 +45,6 @@ spec:
   pipelineRef:
     name: odh-base-containers-pull-request
   taskRunSpecs:
-    - pipelineTaskName: clair-scan
-      stepSpecs:
-        - name: get-vulnerabilities
-          computeResources:
-            requests:
-              memory: 4Gi
-            limits:
-              memory: 8Gi
-        - name: oci-attach-report
-          computeResources:
-            requests:
-              memory: 4Gi
-            limits:
-              memory: 8Gi
     - pipelineTaskName: clamav-scan
       stepSpecs:
         - name: extract-and-scan-image
@@ -67,6 +53,22 @@ spec:
               memory: 4Gi
             limits:
               memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-rocm-base-7-1-pull-request.yaml
+++ b/.tekton/odh-midstream-rocm-base-7-1-pull-request.yaml
@@ -59,6 +59,14 @@ spec:
               memory: 4Gi
             limits:
               memory: 8Gi
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-rocm-base-7-1-push.yaml
+++ b/.tekton/odh-midstream-rocm-base-7-1-push.yaml
@@ -42,20 +42,6 @@ spec:
   pipelineRef:
     name: odh-base-containers-push
   taskRunSpecs:
-    - pipelineTaskName: clair-scan
-      stepSpecs:
-        - name: get-vulnerabilities
-          computeResources:
-            requests:
-              memory: 4Gi
-            limits:
-              memory: 8Gi
-        - name: oci-attach-report
-          computeResources:
-            requests:
-              memory: 4Gi
-            limits:
-              memory: 8Gi
     - pipelineTaskName: clamav-scan
       stepSpecs:
         - name: extract-and-scan-image
@@ -64,6 +50,22 @@ spec:
               memory: 4Gi
             limits:
               memory: 12Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
+    - pipelineTaskName: build-images
+      stepSpecs:
+        - name: sbom-syft-generate
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 8Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-rocm-base-7-1-push.yaml
+++ b/.tekton/odh-midstream-rocm-base-7-1-push.yaml
@@ -56,6 +56,14 @@ spec:
               memory: 4Gi
             limits:
               memory: 8Gi
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 12Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check


### PR DESCRIPTION
## Summary

- Adds uniform taskRunSpecs step-level memory overrides across all 16 Konflux pipeline files (CUDA, ROCm, Python) to mitigate recurring OOM kills
- Over the past 3 months, ~21% of push pipeline runs failed, with 78% of failures caused by OOM in infrastructure tasks
- Every pipeline now overrides 4 tasks: clamav-scan, clair-scan, build-images (syft step), and ecosystem-cert-preflight-checks

### Per-vendor overrides

| Task | Step | All vendors |
|------|------|------------|
| clamav-scan | extract-and-scan-image | req 4Gi / limit 12Gi |
| clair-scan | get-vulnerabilities | req 4Gi / limit 8Gi |
| build-images | sbom-syft-generate | req 4Gi / limit 8Gi |

| Task | Step | CUDA | ROCm | Python |
|------|------|------|------|--------|
| ecosystem-cert | app-check mem | 8Gi / 12Gi | 16Gi / 20Gi | 4Gi / 8Gi |
| ecosystem-cert | app-check cpu | 2 / 4 | 8 / 8 | (default) |

## Test plan

- [x] YAML validity verified on all 16 files
- [x] Automated verification script confirms correct task order, memory, and CPU values per vendor
- [ ] Konflux PR pipelines pass on this branch

Signed-off-by: Víctor M. Múgica <vmugicag@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pipeline configurations across CUDA, ROCm and Python base variants to add per-step memory allocations for scanning and SBOM generation (higher requests/limits), improving resource availability during scans and SBOM creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->