### PR TITLE
Add CODEOWNERS for automatic PR reviewer assignment

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+# CODEOWNERS for opendatahub-io/base-containers
+#
+# Automatic PR reviewer assignment.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners — active contributors from @opendatahub-io/base-containers
+* @LalatenduMohanty @smoparth @Victoremepunto @shifa-khan
+
+# Konflux / Tekton pipelines — CI/CD specialist + primary maintainer
+.tekton/ @Victoremepunto @LalatenduMohanty


### PR DESCRIPTION
Lists the 4 active contributors from @opendatahub-io/base-containers as default owners, with a .tekton/ override for the CI/CD specialist.

## What
<!-- Brief description of the change -->


## Why
<!-- Link to issue or motivation -->

Closes #

## Checklist
<!-- Check items that apply. Strike through items that don't apply to this PR: ~[ ]~ -->

### All PRs
- [ ] Linting, formatting, and type checks pass (`tox -e lint`, `tox -e type`)
- [ ] Tests added/updated where applicable (`tox -e test`)

### Containerfile / image changes
- [ ] Edited the `Containerfile.*.template`, not version-specific `<type>/<version>/Containerfile` directly
- [ ] Regenerated version-specific Containerfiles (`./scripts/generate-containerfile.sh`)
- [ ] Containerfile linting passes (`./scripts/lint-containerfile.sh`)
- [ ] Versions and URLs are in `app.conf` build args, not hardcoded
- [ ] Image builds successfully (`./scripts/build.sh <type>-<version>`)
- [ ] No `:latest` tags or root (UID 0) user in container images


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added code ownership configuration to streamline repository management and code review assignment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->