### PR TITLE
Add ARM64 support for Python and CUDA midstream base images.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
             any-cuda:
               - 'cuda/**/Containerfile'
               - 'cuda/**/app.conf'
+              - '.tekton/odh-midstream-cuda-base-*.yaml'
+              - '.github/workflows/ci.yml'
               - 'scripts/fix-permissions'
               - 'scripts/build.sh'
               - 'requirements-build.txt'
@@ -74,6 +76,8 @@ jobs:
             any-python:
               - 'python/**/Containerfile'
               - 'python/**/app.conf'
+              - '.tekton/odh-midstream-python-base-3-12-*.yaml'
+              - '.github/workflows/ci.yml'
               - 'scripts/fix-permissions'
               - 'scripts/build.sh'
               - 'requirements-build.txt'
@@ -127,7 +131,7 @@ jobs:
             local type="$1"
             local files="$2"
             echo "$files" | grep -qE \
-              "requirements-build\.txt|scripts/fix-permissions|scripts/build\.sh|\.dockerignore|tests/"
+              "requirements-build\.txt|scripts/fix-permissions|scripts/build\.sh|\.dockerignore|tests/|^\.github/workflows/ci\.yml$|^\.tekton/"
           }
 
           # Build matrix for each image type
@@ -290,6 +294,64 @@ jobs:
         env:
           PYTHON_IMAGE: ${{ env.IMAGE_REGISTRY }}/odh-midstream-python-base:${{ steps.config.outputs.tag }}
           PYTHON_VERSION: ${{ matrix.version }}
+          EXPECTED_ARCH: x86_64
+        run: pytest tests/test_python_image.py tests/test_common.py -v
+
+  test-python-image-arm64:
+    name: Test Python ${{ matrix.version }} Image (arm64)
+    runs-on: ubuntu-24.04-arm
+    needs: [lint, type-check, changes, lint-containerfiles]
+    # Run when Python-related files change AND lint-containerfiles passed/skipped
+    if: |
+      always() &&
+      needs.changes.outputs['any-python'] == 'true' &&
+      needs.changes.outputs.python-versions != '' &&
+      needs.changes.outputs.python-versions != '[]' &&
+      needs.lint.result == 'success' &&
+      needs.type-check.result == 'success' &&
+      (needs.lint-containerfiles.result == 'success' || needs.lint-containerfiles.result == 'skipped')
+    strategy:
+      matrix:
+        version: ${{ fromJSON(needs.changes.outputs.python-versions || '[]') }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: pip install -e ".[test]"
+
+      - name: Get image tag from config
+        id: config
+        env:
+          VERSION: ${{ matrix.version }}
+        run: |
+          # Validate version format to prevent injection
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: ${VERSION}"
+            exit 1
+          fi
+          TAG=$(grep '^IMAGE_TAG=' "python/${VERSION}/app.conf" | cut -d'=' -f2)
+          if [ -z "$TAG" ]; then
+            echo "::error::IMAGE_TAG not found in python/${VERSION}/app.conf"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build Python ${{ matrix.version }} image
+        env:
+          VERSION: ${{ matrix.version }}
+        run: ./scripts/build.sh "python-${VERSION}"
+
+      - name: Run Python image tests
+        env:
+          PYTHON_IMAGE: ${{ env.IMAGE_REGISTRY }}/odh-midstream-python-base:${{ steps.config.outputs.tag }}
+          PYTHON_VERSION: ${{ matrix.version }}
+          EXPECTED_ARCH: aarch64
         run: pytest tests/test_python_image.py tests/test_common.py -v
 
   test-cuda-image:
@@ -382,6 +444,100 @@ jobs:
         env:
           CUDA_IMAGE: ${{ env.IMAGE_REGISTRY }}/odh-midstream-cuda-base:${{ steps.config.outputs.tag }}
           CUDA_VERSION: ${{ matrix.version }}
+          EXPECTED_ARCH: x86_64
+        run: pytest tests/test_cuda_image.py tests/test_common.py -v
+
+  test-cuda-image-arm64:
+    name: Test CUDA ${{ matrix.version }} Image (arm64)
+    runs-on: ubuntu-24.04-arm
+    needs: [lint, type-check, changes, lint-containerfiles]
+    # Run when CUDA-related files change AND lint-containerfiles passed/skipped
+    if: |
+      always() &&
+      needs.changes.outputs['any-cuda'] == 'true' &&
+      needs.changes.outputs.cuda-versions != '' &&
+      needs.changes.outputs.cuda-versions != '[]' &&
+      needs.lint.result == 'success' &&
+      needs.type-check.result == 'success' &&
+      (needs.lint-containerfiles.result == 'success' || needs.lint-containerfiles.result == 'skipped')
+    strategy:
+      matrix:
+        version: ${{ fromJSON(needs.changes.outputs.cuda-versions || '[]') }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6
+
+      # Free disk space for CUDA build (~14GB image)
+      # https://github.com/jlumbroso/free-disk-space
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false  # Keep for actions/setup-python
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      # Additional cleanup (complements jlumbroso action)
+      # Referenced from: https://github.com/opendatahub-io/notebooks/.github/actions/free-up-disk-space
+      - name: Additional disk cleanup
+        run: |
+          # Run cleanup in parallel for speed
+          sudo rm -rf /usr/local/.ghcup &
+          sudo rm -rf /usr/local/share/boost &
+          sudo rm -rf /usr/local/lib/node_modules &
+          sudo rm -rf /opt/hostedtoolcache/CodeQL &
+          sudo rm -rf /opt/hostedtoolcache/go &
+          sudo rm -rf /opt/hostedtoolcache/Ruby &
+          sudo rm -rf /opt/hostedtoolcache/PyPy &
+          wait
+
+          # Show available space
+          echo "=== Available disk space ==="
+          df -h /
+          AVAILABLE=$(df -BG / | tail -1 | awk '{print $4}' | tr -d 'G')
+          echo "Available: ${AVAILABLE}GB"
+          if [ "$AVAILABLE" -lt 30 ]; then
+            echo "::warning::Less than 30GB available for CUDA build"
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: pip install -e ".[test]"
+
+      - name: Get image tag from config
+        id: config
+        env:
+          VERSION: ${{ matrix.version }}
+        run: |
+          # Validate version format to prevent injection
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: ${VERSION}"
+            exit 1
+          fi
+          TAG=$(grep '^IMAGE_TAG=' "cuda/${VERSION}/app.conf" | cut -d'=' -f2)
+          if [ -z "$TAG" ]; then
+            echo "::error::IMAGE_TAG not found in cuda/${VERSION}/app.conf"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build CUDA ${{ matrix.version }} image
+        env:
+          VERSION: ${{ matrix.version }}
+        run: ./scripts/build.sh "cuda-${VERSION}"
+
+      - name: Run CUDA image tests
+        env:
+          CUDA_IMAGE: ${{ env.IMAGE_REGISTRY }}/odh-midstream-cuda-base:${{ steps.config.outputs.tag }}
+          CUDA_VERSION: ${{ matrix.version }}
+          EXPECTED_ARCH: aarch64
         run: pytest tests/test_cuda_image.py tests/test_common.py -v
 
   test-rocm-image:
@@ -488,7 +644,9 @@ jobs:
       - type-check
       - lint-containerfiles
       - test-python-image
+      - test-python-image-arm64
       - test-cuda-image
+      - test-cuda-image-arm64
       - test-rocm-image
     steps:
       - name: Check CI status
@@ -497,7 +655,9 @@ jobs:
           echo "type-check: ${{ needs.type-check.result }}"
           echo "lint-containerfiles: ${{ needs.lint-containerfiles.result }}"
           echo "test-python-image: ${{ needs.test-python-image.result }}"
+          echo "test-python-image-arm64: ${{ needs.test-python-image-arm64.result }}"
           echo "test-cuda-image: ${{ needs.test-cuda-image.result }}"
+          echo "test-cuda-image-arm64: ${{ needs.test-cuda-image-arm64.result }}"
           echo "test-rocm-image: ${{ needs.test-rocm-image.result }}"
 
           # Fail if any required job failed or was cancelled
@@ -510,8 +670,12 @@ jobs:
                 "${{ needs.lint-containerfiles.result }}" == "cancelled" || \
                 "${{ needs.test-python-image.result }}" == "failure" || \
                 "${{ needs.test-python-image.result }}" == "cancelled" || \
+                "${{ needs.test-python-image-arm64.result }}" == "failure" || \
+                "${{ needs.test-python-image-arm64.result }}" == "cancelled" || \
                 "${{ needs.test-cuda-image.result }}" == "failure" || \
                 "${{ needs.test-cuda-image.result }}" == "cancelled" || \
+                "${{ needs.test-cuda-image-arm64.result }}" == "failure" || \
+                "${{ needs.test-cuda-image-arm64.result }}" == "cancelled" || \
                 "${{ needs.test-rocm-image.result }}" == "failure" || \
                 "${{ needs.test-rocm-image.result }}" == "cancelled" ]]; then
             echo "::error::One or more CI jobs failed or were cancelled"

--- a/.tekton/odh-midstream-cuda-base-12-8-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-8-pull-request.yaml
@@ -38,6 +38,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/12.8/Containerfile
   - name: build-args-file

--- a/.tekton/odh-midstream-cuda-base-12-8-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-8-pull-request.yaml
@@ -61,7 +61,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 12Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate

--- a/.tekton/odh-midstream-cuda-base-12-8-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-8-push.yaml
@@ -35,6 +35,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/12.8/Containerfile
   - name: build-args-file

--- a/.tekton/odh-midstream-cuda-base-12-8-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-8-push.yaml
@@ -58,7 +58,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 12Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate

--- a/.tekton/odh-midstream-cuda-base-12-9-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-9-pull-request.yaml
@@ -38,6 +38,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/12.9/Containerfile
   - name: build-args-file

--- a/.tekton/odh-midstream-cuda-base-12-9-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-9-pull-request.yaml
@@ -61,7 +61,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 12Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate

--- a/.tekton/odh-midstream-cuda-base-12-9-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-9-push.yaml
@@ -35,6 +35,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/12.9/Containerfile
   - name: build-args-file

--- a/.tekton/odh-midstream-cuda-base-12-9-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-9-push.yaml
@@ -58,7 +58,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 12Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate

--- a/.tekton/odh-midstream-cuda-base-13-0-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-0-pull-request.yaml
@@ -38,6 +38,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/13.0/Containerfile
   - name: build-args-file

--- a/.tekton/odh-midstream-cuda-base-13-0-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-0-pull-request.yaml
@@ -61,7 +61,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 12Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate

--- a/.tekton/odh-midstream-cuda-base-13-0-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-0-push.yaml
@@ -35,6 +35,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/13.0/Containerfile
   - name: build-args-file

--- a/.tekton/odh-midstream-cuda-base-13-0-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-0-push.yaml
@@ -58,7 +58,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 12Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate

--- a/.tekton/odh-midstream-cuda-base-13-1-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-1-pull-request.yaml
@@ -38,6 +38,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/13.1/Containerfile
   - name: build-args-file

--- a/.tekton/odh-midstream-cuda-base-13-1-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-1-pull-request.yaml
@@ -61,7 +61,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 12Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate

--- a/.tekton/odh-midstream-cuda-base-13-1-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-1-push.yaml
@@ -35,6 +35,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/13.1/Containerfile
   - name: build-args-file

--- a/.tekton/odh-midstream-cuda-base-13-1-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-1-push.yaml
@@ -58,7 +58,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 12Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate

--- a/.tekton/odh-midstream-cuda-base-13-2-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-2-pull-request.yaml
@@ -38,6 +38,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/13.2/Containerfile
   - name: build-args-file

--- a/.tekton/odh-midstream-cuda-base-13-2-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-2-pull-request.yaml
@@ -61,7 +61,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 12Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate

--- a/.tekton/odh-midstream-cuda-base-13-2-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-2-push.yaml
@@ -35,6 +35,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/13.2/Containerfile
   - name: build-args-file

--- a/.tekton/odh-midstream-cuda-base-13-2-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-2-push.yaml
@@ -58,7 +58,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 12Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate

--- a/.tekton/odh-midstream-python-base-3-12-pull-request.yaml
+++ b/.tekton/odh-midstream-python-base-3-12-pull-request.yaml
@@ -38,6 +38,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: python/3.12/Containerfile
   - name: build-args-file

--- a/.tekton/odh-midstream-python-base-3-12-push.yaml
+++ b/.tekton/odh-midstream-python-base-3-12-push.yaml
@@ -35,6 +35,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: python/3.12/Containerfile
   - name: build-args-file

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -99,6 +99,14 @@ Use the build script to build container images:
 ./scripts/build.sh all
 ```
 
+The Python 3.12 and CUDA base images build natively on both x86_64 and aarch64 hosts.
+On an aarch64 machine, run `./scripts/build.sh python-3.12` or `./scripts/build.sh cuda-12.8`
+to build the arm64 variant locally. Published images (e.g.
+`quay.io/opendatahub/odh-midstream-python-base-3-12`,
+`quay.io/opendatahub/odh-midstream-cuda-base-12-8`) are multi-arch manifests with
+`linux/amd64` and `linux/arm64` platforms, built via Konflux. ROCm images remain
+x86_64-only.
+
 ## Running Tests
 
 Tests require the container images to be built first and their names passed via environment variables.
@@ -136,6 +144,7 @@ ROCM_IMAGE=<image:tag> pytest tests/test_rocm_image.py tests/test_common.py -v
 | `CUDA_IMAGE` | CUDA base image to test | `quay.io/opendatahub/odh-midstream-cuda-base-12-8` |
 | `ROCM_IMAGE` | ROCm base image to test (x86_64 only) | `quay.io/opendatahub/odh-midstream-rocm-base-6-4` |
 | `PYTHON_VERSION` | Expected Python version for validation | `3.12` |
+| `EXPECTED_ARCH` | Expected container architecture (`uname -m`) | `x86_64`, `aarch64` |
 | `CUDA_VERSION` | Expected CUDA version for validation | `12.8`, `12.9`, `13.0`, `13.1`, `13.2` |
 | `ROCM_VERSION` | Expected ROCm version for validation | `6.4`, `7.1` |
 
@@ -162,7 +171,9 @@ GitHub Actions automatically runs on every PR and push to `main`:
 | `type-check` | PR, push | Runs `mypy` type checking |
 | `lint-containerfiles` | PR, push | Lints changed Containerfiles with Hadolint |
 | `test-python-image` | PR, push | Builds Python image and runs tests when Python-related files change |
+| `test-python-image-arm64` | PR, push | Builds Python image on arm64 and runs tests when Python-related files change |
 | `test-cuda-image` | PR, push | Builds CUDA image and runs tests when CUDA-related files change |
+| `test-cuda-image-arm64` | PR, push | Builds CUDA image on arm64 and runs tests when CUDA-related files change |
 | `test-rocm-image` | PR, push | Builds ROCm image and runs tests when ROCm-related files change |
 | `ci-status` | PR, push | Aggregates required jobs for branch protection |
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4,6 +4,8 @@ These tests verify core functionality that should work identically
 across all ODH base container images.
 """
 
+import os
+
 import pytest
 
 from tests import APP_ROOT, WORKDIR, redact_url_credentials
@@ -66,6 +68,27 @@ def test_uv_pip_compile_smoke(container):
         "uv pip compile failed — broken index-url, missing CA certs, "
         f"or malformed /etc/uv/uv.toml\nstderr: {redact_url_credentials(result.stderr)}"
     )
+
+
+def test_image_architecture(container):
+    """Verify container architecture when EXPECTED_ARCH is set."""
+    expected = os.environ.get("EXPECTED_ARCH")
+    if not expected:
+        pytest.skip("EXPECTED_ARCH not set — skipping architecture validation")
+
+    result = container.run("uname -m")
+    assert result.returncode == 0
+    actual = result.stdout.strip()
+
+    # Normalize common architecture aliases
+    arch_aliases = {
+        "x86_64": {"x86_64", "amd64"},
+        "amd64": {"x86_64", "amd64"},
+        "aarch64": {"aarch64", "arm64"},
+        "arm64": {"aarch64", "arm64"},
+    }
+    allowed = arch_aliases.get(expected, {expected})
+    assert actual in allowed, f"Expected architecture {expected}, got: {actual}"
 
 
 # --- User & Permission Tests ---


### PR DESCRIPTION
Enable linux/arm64 in Konflux pipelines, arm64 CI jobs, and architecture validation tests. Fixes #236.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ARM64 (aarch64) build targets alongside x86_64 for Python and CUDA base images; CI runs dedicated ARM64 image tests and requires them in status aggregation
  * Increased memory for vulnerability scan steps to improve scan reliability

* **Documentation**
  * Updated build docs with multi-architecture instructions and CI job details

* **Tests**
  * Added container architecture validation test that checks EXPECTED_ARCH
<!-- end of auto-generated comment: release notes by coderabbit.ai -->