### PR TITLE
ci: fix GPU build failures from undersized VMs and OOM scan tasks

### DIFF
--- a/.tekton/odh-midstream-cuda-base-12-8-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-8-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
     - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/12.8/Containerfile
@@ -53,7 +53,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: clair-scan
       stepSpecs:
         - name: get-vulnerabilities
@@ -61,7 +61,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate
@@ -69,7 +69,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 16Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-12-8-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-8-push.yaml
@@ -34,7 +34,7 @@ spec:
     value: quay.io/opendatahub/odh-midstream-cuda-base-12-8:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
     - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/12.8/Containerfile
@@ -50,7 +50,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: clair-scan
       stepSpecs:
         - name: get-vulnerabilities
@@ -58,7 +58,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate
@@ -66,7 +66,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 16Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-12-9-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-9-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
     - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/12.9/Containerfile
@@ -53,7 +53,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: clair-scan
       stepSpecs:
         - name: get-vulnerabilities
@@ -61,7 +61,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate
@@ -69,7 +69,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 16Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-12-9-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-12-9-push.yaml
@@ -34,7 +34,7 @@ spec:
     value: quay.io/opendatahub/odh-midstream-cuda-base-12-9:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
     - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/12.9/Containerfile
@@ -50,7 +50,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: clair-scan
       stepSpecs:
         - name: get-vulnerabilities
@@ -58,7 +58,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate
@@ -66,7 +66,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 16Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-0-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-0-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
     - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/13.0/Containerfile
@@ -53,7 +53,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: clair-scan
       stepSpecs:
         - name: get-vulnerabilities
@@ -61,7 +61,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate
@@ -69,7 +69,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 16Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-0-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-0-push.yaml
@@ -34,7 +34,7 @@ spec:
     value: quay.io/opendatahub/odh-midstream-cuda-base-13-0:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
     - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/13.0/Containerfile
@@ -50,7 +50,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: clair-scan
       stepSpecs:
         - name: get-vulnerabilities
@@ -58,7 +58,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate
@@ -66,7 +66,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 16Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-1-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-1-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
     - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/13.1/Containerfile
@@ -53,7 +53,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: clair-scan
       stepSpecs:
         - name: get-vulnerabilities
@@ -61,7 +61,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate
@@ -69,7 +69,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 16Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-1-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-1-push.yaml
@@ -34,7 +34,7 @@ spec:
     value: quay.io/opendatahub/odh-midstream-cuda-base-13-1:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
     - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/13.1/Containerfile
@@ -50,7 +50,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: clair-scan
       stepSpecs:
         - name: get-vulnerabilities
@@ -58,7 +58,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate
@@ -66,7 +66,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 16Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-2-pull-request.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-2-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
     - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/13.2/Containerfile
@@ -53,7 +53,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: clair-scan
       stepSpecs:
         - name: get-vulnerabilities
@@ -61,7 +61,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate
@@ -69,7 +69,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 16Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-cuda-base-13-2-push.yaml
+++ b/.tekton/odh-midstream-cuda-base-13-2-push.yaml
@@ -34,7 +34,7 @@ spec:
     value: quay.io/opendatahub/odh-midstream-cuda-base-13-2:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
     - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: cuda/13.2/Containerfile
@@ -50,7 +50,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: clair-scan
       stepSpecs:
         - name: get-vulnerabilities
@@ -58,7 +58,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 16Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate
@@ -66,7 +66,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 16Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-rocm-base-6-4-pull-request.yaml
+++ b/.tekton/odh-midstream-rocm-base-6-4-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: rocm/6.4/Containerfile
   - name: build-args-file
@@ -52,7 +52,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 24Gi
     - pipelineTaskName: clair-scan
       stepSpecs:
         - name: get-vulnerabilities
@@ -60,7 +60,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 24Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate
@@ -68,7 +68,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 24Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-rocm-base-6-4-push.yaml
+++ b/.tekton/odh-midstream-rocm-base-6-4-push.yaml
@@ -34,7 +34,7 @@ spec:
     value: quay.io/opendatahub/odh-midstream-rocm-base-6-4:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: rocm/6.4/Containerfile
   - name: build-args-file
@@ -49,7 +49,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 24Gi
     - pipelineTaskName: clair-scan
       stepSpecs:
         - name: get-vulnerabilities
@@ -57,7 +57,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 24Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate
@@ -65,7 +65,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 24Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-rocm-base-7-1-pull-request.yaml
+++ b/.tekton/odh-midstream-rocm-base-7-1-pull-request.yaml
@@ -37,7 +37,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: rocm/7.1/Containerfile
   - name: build-args-file
@@ -52,7 +52,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 24Gi
     - pipelineTaskName: clair-scan
       stepSpecs:
         - name: get-vulnerabilities
@@ -60,7 +60,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 24Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate
@@ -68,7 +68,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 24Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check

--- a/.tekton/odh-midstream-rocm-base-7-1-push.yaml
+++ b/.tekton/odh-midstream-rocm-base-7-1-push.yaml
@@ -34,7 +34,7 @@ spec:
     value: quay.io/opendatahub/odh-midstream-rocm-base-7-1:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: rocm/7.1/Containerfile
   - name: build-args-file
@@ -49,7 +49,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 12Gi
+              memory: 24Gi
     - pipelineTaskName: clair-scan
       stepSpecs:
         - name: get-vulnerabilities
@@ -57,7 +57,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 24Gi
     - pipelineTaskName: build-images
       stepSpecs:
         - name: sbom-syft-generate
@@ -65,7 +65,7 @@ spec:
             requests:
               memory: 4Gi
             limits:
-              memory: 8Gi
+              memory: 24Gi
     - pipelineTaskName: ecosystem-cert-preflight-checks
       stepSpecs:
         - name: app-check


### PR DESCRIPTION
## Summary

- Use `linux-d160-m2xlarge/amd64` (160 GB disk, 8 CPU, 32 GB RAM) for x86_64 GPU builds instead of the default `linux/x86_64` (40 GB disk). This matches the ARM64 instance class already in use and provides enough disk for our 11-19 GB GPU images with buildah overhead.
- Bump scan/SBOM task memory limits sized to image footprints:
  - **CUDA** (11-13.5 GB uncompressed): syft 8→16Gi, clamav 12→16Gi, clair 12→16Gi
  - **ROCm** (19.4 GB uncompressed): syft 8→24Gi, clamav 12→24Gi, clair 8→24Gi
- Python images (1.2 GB) are unaffected — their limits remain unchanged.

Fixes #256, fixes #260

## Test plan

- [ ] Verify CUDA 12.8 PR pipeline passes (largest CUDA image, previously `no space left on device`)
- [ ] Verify ROCm 6.4 PR pipeline passes (largest image at 19.4 GB, previously OOM on syft)
- [ ] Verify Python 3.12 builds are unaffected
- [ ] Confirm scan tasks (syft, clamav, clair) complete without OOMKill

Signed-off-by: Víctor M. Múgica <vmugicag@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build platform configurations for CUDA and ROCm base image pipelines to use optimized compute resources.
  * Increased memory allocation for image scanning and software bill of materials generation processes to enhance build performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->