### PR TITLE
ci: trigger tests when test infrastructure files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
               - 'tests/conftest.py'
               - 'tests/test_cuda_image.py'
               - 'tests/__init__.py'
+              - 'pyproject.toml'
+              - 'tox.ini'
             any-rocm:
               - 'rocm/**/Containerfile'
               - 'rocm/**/app.conf'
@@ -73,6 +75,8 @@ jobs:
               - 'tests/conftest.py'
               - 'tests/test_rocm_image.py'
               - 'tests/__init__.py'
+              - 'pyproject.toml'
+              - 'tox.ini'
             any-python:
               - 'python/**/Containerfile'
               - 'python/**/app.conf'
@@ -86,6 +90,8 @@ jobs:
               - 'tests/conftest.py'
               - 'tests/test_python_image.py'
               - 'tests/__init__.py'
+              - 'pyproject.toml'
+              - 'tox.ini'
               
       - name: Build version matrices
         id: build-matrices
@@ -131,7 +137,7 @@ jobs:
             local type="$1"
             local files="$2"
             echo "$files" | grep -qE \
-              "requirements-build\.txt|scripts/fix-permissions|scripts/build\.sh|\.dockerignore|tests/|^\.github/workflows/ci\.yml$|^\.tekton/"
+              "requirements-build\.txt|scripts/fix-permissions|scripts/build\.sh|\.dockerignore|tests/|\.github/workflows/ci\.yml|\.tekton/|pyproject\.toml|tox\.ini"
           }
 
           # Build matrix for each image type


### PR DESCRIPTION
Add pyproject.toml and tox.ini to all three paths-filter groups (any-cuda, any-rocm, any-python) so that changes to test tooling (e.g. Renovate dependency bumps) trigger a full test run.

Closes #263

## What
<!-- Brief description of the change -->


## Why
<!-- Link to issue or motivation -->

Closes #

## Checklist
<!-- Check items that apply. Strike through items that don't apply to this PR: ~[ ]~ -->

### All PRs
- [x] Linting, formatting, and type checks pass (`tox -e lint`, `tox -e type`)
- [ ] Tests added/updated where applicable (`tox -e test`)

### Containerfile / image changes
- [ ] Edited the `Containerfile.*.template`, not version-specific `<type>/<version>/Containerfile` directly
- [ ] Regenerated version-specific Containerfiles (`./scripts/generate-containerfile.sh`)
- [ ] Containerfile linting passes (`./scripts/lint-containerfile.sh`)
- [ ] Versions and URLs are in `app.conf` build args, not hardcoded
- [ ] Image builds successfully (`./scripts/build.sh <type>-<version>`)
- [ ] No `:latest` tags or root (UID 0) user in container images


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI change-detection to treat `pyproject.toml` and `tox.ini` as inputs, so edits to project configuration reliably trigger the appropriate rebuilds (including for CUDA/ROCm/Python-related images).
  * Adjusted how “common” paths are recognized during change evaluation to ensure the correct rebuild behavior when workflow or shared directories are modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->