### PR TITLE
ci: enable hermetic builds for Python 3.12 image

### DIFF
--- a/.tekton/odh-midstream-python-base-3-12-pull-request.yaml
+++ b/.tekton/odh-midstream-python-base-3-12-pull-request.yaml
@@ -43,6 +43,10 @@ spec:
     value: python/3.12/Containerfile
   - name: build-args-file
     value: python/3.12/app.conf
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "pip", "path": ".", "requirements_files": ["requirements-build.txt"], "allow_binary": true}'
   pipelineRef:
     name: odh-base-containers-pull-request
   taskRunSpecs:

--- a/.tekton/odh-midstream-python-base-3-12-push.yaml
+++ b/.tekton/odh-midstream-python-base-3-12-push.yaml
@@ -40,6 +40,10 @@ spec:
     value: python/3.12/Containerfile
   - name: build-args-file
     value: python/3.12/app.conf
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "pip", "path": ".", "requirements_files": ["requirements-build.txt"], "allow_binary": true}'
   pipelineRef:
     name: odh-base-containers-push
   taskRunSpecs:


### PR DESCRIPTION
## Summary

- Enable network-isolated (hermetic) builds for the Python 3.12 midstream base image
- Set `hermetic: "true"` and configure pip `prefetch-input` in both push and pull-request PipelineRun YAMLs
- The existing `requirements-build.txt` (`uv==0.11.25` with `--require-hashes`) serves as the pip lockfile
- `allow_binary: true` is required because `uv` is a Rust binary distributed as platform-specific wheels

Partial fix for #248

## How it works

The Konflux pipeline plumbing (`prefetch-dependencies` task, `CACHI2_ARTIFACT` wiring) is already wired in `.tekton/pipelines/{push,pull-request}.yaml`. This PR passes the params from the PipelineRun to activate it:

1. `prefetch-dependencies` task runs Hermeto to download `uv` wheels before the build
2. `build-images` task runs with `--network none`, using prefetched wheels via `PIP_FIND_LINKS` / `PIP_NO_INDEX`
3. Konflux auto-injects `source /cachi2/cachi2.env` into the Containerfile at build time — no Containerfile changes needed

## Test plan

- [ ] PR pipeline triggers and `prefetch-dependencies` task succeeds (downloads `uv` wheel)
- [ ] `build-images` task succeeds in hermetic (no-network) mode on both x86_64 and arm64
- [ ] Built image contains working `uv` installation

Signed-off-by: Víctor M. Múgica <vmugicag@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled hermetic build mode for Python 3.12 pipeline runs.
  * Added pip prefetch settings so build inputs can be prepared from the repository using the build requirements file, with support for binary packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->