### PR TITLE
fix(python): use UV_TORCH_BACKEND=cpu instead of extra-index-url in uv.toml

### DIFF
--- a/Containerfile.python.template
+++ b/Containerfile.python.template
@@ -67,6 +67,7 @@ USER 0
 
 ARG PIP_INDEX_URL
 ARG PIP_EXTRA_INDEX_URL
+ARG UV_TORCH_BACKEND=
 
 # pip configuration (system-wide) - must be created before installing uv
 RUN mkdir -p /etc/pip && \
@@ -84,10 +85,14 @@ RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-b
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)
+# Note: PIP_EXTRA_INDEX_URL is intentionally omitted from uv.toml because
+# UV_TORCH_BACKEND is uv's native mechanism for PyTorch CPU wheel resolution.
+# torch-backend is written to uv.toml (not ENV) to avoid uv erroring on empty values.
+# Downstream builds can disable by omitting UV_TORCH_BACKEND or rebuilding uv.toml.
 RUN mkdir -p /etc/uv && \
     { echo "[pip]"; \
       echo "index-url = \"${PIP_INDEX_URL}\""; \
-      [ -n "${PIP_EXTRA_INDEX_URL}" ] && echo "extra-index-url = [\"${PIP_EXTRA_INDEX_URL}\"]"; \
+      [ -n "${UV_TORCH_BACKEND}" ] && echo "torch-backend = \"${UV_TORCH_BACKEND}\""; \
       true; \
     } > /etc/uv/uv.toml
 ENV UV_CONFIG_FILE=/etc/uv/uv.toml
@@ -152,6 +157,7 @@ WORKDIR /opt/app-root/src
 #   podman build -t myapp:rhoai \
 #     --build-arg PIP_INDEX_URL=https://aipcc.internal/simple \
 #     --build-arg PIP_EXTRA_INDEX_URL="" \
+#     --build-arg UV_TORCH_BACKEND= \
 #     .
 #
 # -----------------------------------------------------------------------------

--- a/python/3.12/Containerfile
+++ b/python/3.12/Containerfile
@@ -67,6 +67,7 @@ USER 0
 
 ARG PIP_INDEX_URL
 ARG PIP_EXTRA_INDEX_URL
+ARG UV_TORCH_BACKEND=
 
 # pip configuration (system-wide) - must be created before installing uv
 RUN mkdir -p /etc/pip && \
@@ -84,10 +85,14 @@ RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-b
     rm /tmp/requirements-build.txt
 
 # uv configuration (system-wide)
+# Note: PIP_EXTRA_INDEX_URL is intentionally omitted from uv.toml because
+# UV_TORCH_BACKEND is uv's native mechanism for PyTorch CPU wheel resolution.
+# torch-backend is written to uv.toml (not ENV) to avoid uv erroring on empty values.
+# Downstream builds can disable by omitting UV_TORCH_BACKEND or rebuilding uv.toml.
 RUN mkdir -p /etc/uv && \
     { echo "[pip]"; \
       echo "index-url = \"${PIP_INDEX_URL}\""; \
-      [ -n "${PIP_EXTRA_INDEX_URL}" ] && echo "extra-index-url = [\"${PIP_EXTRA_INDEX_URL}\"]"; \
+      [ -n "${UV_TORCH_BACKEND}" ] && echo "torch-backend = \"${UV_TORCH_BACKEND}\""; \
       true; \
     } > /etc/uv/uv.toml
 ENV UV_CONFIG_FILE=/etc/uv/uv.toml
@@ -152,6 +157,7 @@ WORKDIR /opt/app-root/src
 #   podman build -t myapp:rhoai \
 #     --build-arg PIP_INDEX_URL=https://aipcc.internal/simple \
 #     --build-arg PIP_EXTRA_INDEX_URL="" \
+#     --build-arg UV_TORCH_BACKEND= \
 #     .
 #
 # -----------------------------------------------------------------------------

--- a/python/3.12/app.conf
+++ b/python/3.12/app.conf
@@ -33,3 +33,12 @@ BASE_IMAGE=registry.access.redhat.com/ubi9/python-312:9.8-1783442686@sha256:c40a
 # -----------------------------------------------------------------------------
 PIP_INDEX_URL=https://pypi.org/simple
 PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
+
+# -----------------------------------------------------------------------------
+# uv Torch Backend
+# -----------------------------------------------------------------------------
+# uv's native mechanism for PyTorch CPU wheel resolution.
+# Routes only torch-ecosystem packages to the torch index; all other packages
+# resolve exclusively from PyPI, producing complete multi-platform hashes.
+# See: https://docs.astral.sh/uv/configuration/indexes/#pytorch
+UV_TORCH_BACKEND=cpu


### PR DESCRIPTION
Replace PIP_EXTRA_INDEX_URL with UV_TORCH_BACKEND in the uv configuration for the Python base image, aligning it with the CUDA and ROCm images.

uv's torch-backend routes only PyTorch-ecosystem packages to the torch index, while all other packages resolve exclusively from PyPI. This produces complete multi-platform hashes in lock files, fixing hash verification failures on architectures not covered by the torch index's limited wheel set.

PIP_EXTRA_INDEX_URL remains in /etc/pip.conf for pip users.

Closes #283

## What
<!-- Brief description of the change -->


## Why
<!-- Link to issue or motivation -->

Closes #

## Checklist
<!-- Check items that apply. Strike through items that don't apply to this PR: ~[ ]~ -->

### All PRs
- [ ] Linting, formatting, and type checks pass (`tox -e lint`, `tox -e type`)
- [ ] Tests added/updated where applicable (`tox -e test`)

### Containerfile / image changes
- [x] Edited the `Containerfile.*.template`, not version-specific `<type>/<version>/Containerfile` directly
- [ ] Regenerated version-specific Containerfiles (`./scripts/generate-containerfile.sh`)
- [x] Containerfile linting passes (`./scripts/lint-containerfile.sh`)
- [x] Versions and URLs are in `app.conf` build args, not hardcoded
- [ ] Image builds successfully (`./scripts/build.sh <type>-<version>`)
- [x] No `:latest` tags or root (UID 0) user in container images


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Torch backend support during image builds, making PyTorch package resolution configurable.
  * Updated the default Python 3.12 app configuration to use a CPU Torch backend.

* **Bug Fixes**
  * Streamlined package index handling so non-Torch packages are resolved from the primary index only, with clearer build-time control over Torch-related behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->