### PR TITLE
feat(rocm): add ROCm 7.14 base image

### DIFF
--- a/.tekton/odh-midstream-rocm-base-7-14-pull-request.yaml
+++ b/.tekton/odh-midstream-rocm-base-7-14-pull-request.yaml
@@ -1,0 +1,87 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/base-containers?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" && target_branch == "main" && (
+        'rocm/7.14/**'.pathChanged() ||
+        'requirements-build.txt'.pathChanged() ||
+        'scripts/fix-permissions'.pathChanged() ||
+        '.dockerignore'.pathChanged() ||
+        '.tekton/odh-midstream-rocm-base-7-14-pull-request.yaml'.pathChanged()
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: odh-base-containers
+    appstudio.openshift.io/component: odh-midstream-rocm-base-7-14
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-midstream-rocm-base-7-14-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  timeouts:
+    pipeline: "4h0m0s"
+    tasks: "4h0m0s"
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-midstream-rocm-base-7-14:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-d160-m2xlarge/amd64
+  - name: dockerfile
+    value: rocm/7.14/Containerfile
+  - name: build-args-file
+    value: rocm/7.14/app.conf
+  pipelineRef:
+    name: odh-base-containers-pull-request
+  taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 24Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 24Gi
+    - pipelineTaskName: build-images
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 24Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      stepSpecs:
+        - name: app-check
+          computeResources:
+            requests:
+              memory: 16Gi
+              cpu: '8'
+            limits:
+              memory: 20Gi
+              cpu: '8'
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-midstream-rocm-base-7-14
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/odh-midstream-rocm-base-7-14-push.yaml
+++ b/.tekton/odh-midstream-rocm-base-7-14-push.yaml
@@ -1,0 +1,84 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/base-containers?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && target_branch == "main" && (
+        'rocm/7.14/**'.pathChanged() ||
+        'requirements-build.txt'.pathChanged() ||
+        'scripts/fix-permissions'.pathChanged() ||
+        '.dockerignore'.pathChanged() ||
+        '.tekton/odh-midstream-rocm-base-7-14-push.yaml'.pathChanged()
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: odh-base-containers
+    appstudio.openshift.io/component: odh-midstream-rocm-base-7-14
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-midstream-rocm-base-7-14-on-push
+  namespace: open-data-hub-tenant
+spec:
+  timeouts:
+    pipeline: "4h0m0s"
+    tasks: "4h0m0s"
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-midstream-rocm-base-7-14:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-d160-m2xlarge/amd64
+  - name: dockerfile
+    value: rocm/7.14/Containerfile
+  - name: build-args-file
+    value: rocm/7.14/app.conf
+  pipelineRef:
+    name: odh-base-containers-push
+  taskRunSpecs:
+    - pipelineTaskName: clamav-scan
+      stepSpecs:
+        - name: extract-and-scan-image
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 24Gi
+    - pipelineTaskName: clair-scan
+      stepSpecs:
+        - name: get-vulnerabilities
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 24Gi
+    - pipelineTaskName: build-images
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 24Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      stepSpecs:
+        - name: app-check
+          computeResources:
+            requests:
+              memory: 16Gi
+              cpu: '8'
+            limits:
+              memory: 20Gi
+              cpu: '8'
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-midstream-rocm-base-7-14
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This repository provides standardized Containerfiles for building Open Data Hub 
 |--------|------------------|------------------------|
 | Python | UBI 9            | 3.12                   |
 | CUDA   | CentOS Stream 9  | 12.8, 12.9, 13.0, 13.1, 13.2 |
-| ROCm   | CentOS Stream 9  | 6.4, 7.1               |
+| ROCm   | CentOS Stream 9  | 6.4, 7.1, 7.14         |
 
 ## Repository Structure
 
@@ -34,9 +34,12 @@ base-containers/
 │   ├── 6.4/
 │   │   ├── Containerfile                 # ROCm 6.4 Containerfile
 │   │   └── app.conf                      # ROCm 6.4 build arguments
-│   └── 7.1/
-│       ├── Containerfile                 # ROCm 7.1 Containerfile
-│       └── app.conf                      # ROCm 7.1 build arguments
+│   ├── 7.1/
+│   │   ├── Containerfile                 # ROCm 7.1 Containerfile
+│   │   └── app.conf                      # ROCm 7.1 build arguments
+│   └── 7.14/
+│       ├── Containerfile                 # ROCm 7.14 Containerfile
+│       └── app.conf                      # ROCm 7.14 build arguments
 ├── python/                               # Python version directories
 │   └── 3.12/
 │       ├── Containerfile                 # Python 3.12 Containerfile
@@ -85,6 +88,7 @@ base-containers/
 ./scripts/build.sh cuda-13.2              # Build CUDA 13.2 image
 ./scripts/build.sh rocm-6.4               # Build ROCm 6.4 image
 ./scripts/build.sh rocm-7.1               # Build ROCm 7.1 image
+./scripts/build.sh rocm-7.14              # Build ROCm 7.14 image
 ./scripts/build.sh python-3.12            # Build Python 3.12 image
 
 # Build all versions of a type
@@ -163,6 +167,7 @@ Config files in `<type>/<version>/app.conf` are passed directly to podman via `-
   `CUDA_MAJOR` (12), `CUDA_MAJOR_MINOR` (12-8), `CUDA_MAJOR_MINOR_DOT` (12.8)
 - ROCm templates use build args from `rocm/<version>/app.conf`:
   `ROCM_MAJOR` (6), `ROCM_MAJOR_MINOR` (6-4), `ROCM_MAJOR_MINOR_DOT` (6.4)
+  ROCm 7.14+ also uses: `THEROCK_REPO_URL`, `ROCM_HOME`
 - Python templates use build args from `python/<version>/app.conf`:
   `PYTHON_VERSION` (3.12), `PYTHON_VERSION_NODOT` (312)
 

--- a/Containerfile.rocm-therock.template
+++ b/Containerfile.rocm-therock.template
@@ -1,0 +1,261 @@
+# ODH ROCm Base Image - TheRock (CentOS Stream 9)
+# ROCm Version: ${ROCM_MAJOR_MINOR_DOT}
+# Generated from Containerfile.rocm-therock.template - edit template, not this file
+#
+# For ROCm 7.14+ which uses TheRock multi-arch packages (amdrocm-*).
+# Legacy ROCm versions (6.4, 7.1) use Containerfile.rocm.template instead.
+#
+# CentOS Stream 9 required: ROCm packages need CentOS Stream 9 / RHEL 9 repos
+# Usage: ./scripts/build.sh rocm-${ROCM_MAJOR_MINOR_DOT}
+# Build args: rocm/${ROCM_MAJOR_MINOR_DOT}/app.conf
+
+ARG BASE_IMAGE
+ARG ROCM_MAJOR
+ARG ROCM_MAJOR_MINOR
+ARG ROCM_MAJOR_MINOR_DOT
+ARG ROCM_VERSION
+ARG RELEASEVER
+
+# TheRock repository URL for amdrocm-* packages
+ARG THEROCK_REPO_URL
+
+# Frameworks repository URL for migraphx packages
+ARG FRAMEWORKS_REPO_URL
+
+# ROCm install prefix (7.14+ uses /opt/rocm/core)
+ARG ROCM_HOME=/opt/rocm/core
+
+# Build metadata for OCI labels
+ARG BUILD_DATE
+ARG VCS_REF=unknown
+ARG VERSION=0.0.1
+
+# -----------------------------------------------------------------------------
+# Base stage (x86_64 only - ROCm does not support ARM64)
+# -----------------------------------------------------------------------------
+FROM ${BASE_IMAGE} AS rocm-base
+
+ARG ROCM_MAJOR
+ARG ROCM_MAJOR_MINOR
+ARG ROCM_MAJOR_MINOR_DOT
+ARG ROCM_VERSION
+ARG RELEASEVER
+ARG THEROCK_REPO_URL
+ARG FRAMEWORKS_REPO_URL
+ARG ROCM_HOME
+
+USER 0
+WORKDIR /opt/app-root/bin
+
+# -----------------------------------------------------------------------------
+# ROCm Version Environment
+# -----------------------------------------------------------------------------
+ENV ROCM_VERSION=${ROCM_VERSION}
+ENV ROCM_HOME=${ROCM_HOME}
+
+# -----------------------------------------------------------------------------
+# TheRock Repository Setup
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf install -y --setopt=keepcache=1 --allowerasing curl ca-certificates
+
+# ROCm GPG keys (GA + TheRock, matching downstream configuration)
+RUN curl -fsSL "https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/pki/rpm-gpg/RPM-GPG-KEY-AMD-ROCM && \
+    curl -fsSL "https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg" > /etc/pki/rpm-gpg/RPM-GPG-KEY-AMD-ROCM-THEROCK
+
+RUN { echo "[therock]"; \
+      echo "name=TheRock ROCm ${ROCM_VERSION}"; \
+      echo "baseurl=${THEROCK_REPO_URL}"; \
+      echo "enabled=1"; \
+      echo "priority=150"; \
+      echo "gpgcheck=1"; \
+      echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AMD-ROCM"; \
+      echo "       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AMD-ROCM-THEROCK"; \
+    } > /etc/yum.repos.d/rocm.repo
+
+# Frameworks repository for migraphx (separate from main TheRock packages)
+RUN { echo "[rocm-frameworks]"; \
+      echo "name=ROCm Frameworks (migraphx)"; \
+      echo "baseurl=${FRAMEWORKS_REPO_URL}"; \
+      echo "enabled=1"; \
+      echo "priority=200"; \
+      echo "gpgcheck=0"; \
+    } > /etc/yum.repos.d/rocm-frameworks.repo
+
+# -----------------------------------------------------------------------------
+# ROCm Packages (TheRock amdrocm-* multi-arch)
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf install -y --setopt=keepcache=1 \
+      gcc-toolset-14 \
+      gcc-toolset-14-gcc-c++ \
+      gcc-toolset-14-gcc-gfortran \
+      gcc-toolset-14-libatomic-devel \
+      libdrm \
+      amdrocm-amdsmi \
+      amdrocm-llvm \
+      amdrocm-runtime \
+      amdrocm-runtime-devel \
+      amdrocm-rccl \
+      amdrocm-rccl-devel \
+      amdrocm-math-common \
+      amdrocm-core-sdk \
+      amdrocm-core-devel \
+      amdrocm-blas \
+      amdrocm-blas-devel \
+      amdrocm-dnn \
+      amdrocm-dnn-devel \
+      amdrocm-fft \
+      amdrocm-fft-devel \
+      amdrocm-solver \
+      amdrocm-solver-devel \
+      amdrocm-sparse \
+      amdrocm-sparse-devel \
+      amdrocm-rand \
+      amdrocm-rand-devel \
+      amdrocm-ccl-devel \
+      amdrocm-migraphx \
+      amdrocm-migraphx-devel
+
+# Configure ROCm library paths
+ENV PATH=${ROCM_HOME}/bin:${ROCM_HOME}/hip/bin:${PATH}
+ENV LD_LIBRARY_PATH=${ROCM_HOME}/lib:${ROCM_HOME}/lib64
+
+# -----------------------------------------------------------------------------
+# Post-install: symlinks for backward compatibility (/opt/rocm -> /opt/rocm/core)
+# -----------------------------------------------------------------------------
+RUN ln -sfn "${ROCM_HOME}"/include /opt/rocm/include && \
+    ln -sfn "${ROCM_HOME}"/lib /opt/rocm/lib && \
+    ln -sfn "${ROCM_HOME}"/bin /opt/rocm/bin && \
+    ln -sfn "${ROCM_HOME}"/share /opt/rocm/share && \
+    for subdir in llvm hip; do \
+      if [ -d "${ROCM_HOME}/${subdir}" ]; then \
+        ln -sfn "${ROCM_HOME}/${subdir}" "/opt/rocm/${subdir}"; \
+      fi; \
+    done
+
+# Fix shebangs in ROCm CLI tools to use system Python
+RUN for script in "${ROCM_HOME}/bin/amd-smi" "${ROCM_HOME}/bin/rocm-smi"; do \
+      if [ -f "${script}" ]; then \
+        sed -i -e '1s,#!/usr/bin/env python3,#!/usr/bin/python3,' "${script}"; \
+      fi; \
+    done
+
+# Register amdsmi package on the Python import path
+RUN if [ -d "${ROCM_HOME}/share/amd_smi" ]; then \
+      echo "${ROCM_HOME}/share/amd_smi" \
+        > "$(python -c "import sysconfig; print(sysconfig.get_path('platlib'))")"/rocm-amdsmi.pth; \
+    fi
+
+# -----------------------------------------------------------------------------
+# ROCm Shared Library Configuration
+# -----------------------------------------------------------------------------
+RUN echo "${ROCM_HOME}/lib" > /etc/ld.so.conf.d/rocm.conf && \
+    echo "${ROCM_HOME}/lib64" >> /etc/ld.so.conf.d/rocm.conf && \
+    printf '%s\n' \
+      "/opt/rh/gcc-toolset-14/root/usr/lib64" \
+      "/opt/rh/gcc-toolset-14/root/usr/lib" \
+      > /etc/ld.so.conf.d/gcc-toolset-14.conf && \
+    ldconfig
+
+# gcc-toolset-14 compiler environment
+ENV PATH=/opt/rh/gcc-toolset-14/root/usr/bin:${PATH} \
+    PKG_CONFIG_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64/pkgconfig
+
+# -----------------------------------------------------------------------------
+# Development Tools
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf install -y --setopt=keepcache=1 make findutils
+
+# -----------------------------------------------------------------------------
+# Environment (consistent with Python base image)
+# -----------------------------------------------------------------------------
+
+# Python settings - prevent bytecode files and enable unbuffered output
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    UV_NO_CACHE=1 \
+    UV_PYTHON_DOWNLOADS=never
+
+# -----------------------------------------------------------------------------
+# Package Index Configuration
+# -----------------------------------------------------------------------------
+ARG PIP_INDEX_URL=https://pypi.org/simple
+ARG PIP_EXTRA_INDEX_URL
+ARG UV_TORCH_BACKEND=
+
+# pip configuration (system-wide)
+RUN mkdir -p /etc/pip && \
+    { echo "[global]"; \
+      echo "index-url = ${PIP_INDEX_URL}"; \
+      [ -n "${PIP_EXTRA_INDEX_URL}" ] && echo "extra-index-url = ${PIP_EXTRA_INDEX_URL}"; \
+      true; \
+    } > /etc/pip.conf
+
+# Install uv - fast Python package installer
+# https://github.com/astral-sh/uv
+# Version pinned in requirements-build.txt
+COPY --chmod=644 --chown=0:0 requirements-build.txt /tmp/requirements-build.txt
+RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-build.txt && \
+    rm /tmp/requirements-build.txt
+
+# uv configuration (system-wide)
+RUN mkdir -p /etc/uv && \
+    { echo "[pip]"; \
+      echo "index-url = \"${PIP_INDEX_URL}\""; \
+      [ -n "${UV_TORCH_BACKEND}" ] && echo "torch-backend = \"${UV_TORCH_BACKEND}\""; \
+      true; \
+    } > /etc/uv/uv.toml
+ENV UV_CONFIG_FILE=/etc/uv/uv.toml
+
+# Copy fix-permissions script from sclorg for OpenShift compatibility
+COPY --chmod=755 --chown=0:0 scripts/fix-permissions /usr/local/bin/fix-permissions
+
+# -----------------------------------------------------------------------------
+# Directory Setup
+# -----------------------------------------------------------------------------
+RUN mkdir -p /opt/app-root/src/.cache && \
+    chown -R 1001:0 /opt/app-root && \
+    fix-permissions /opt/app-root -P
+
+# -----------------------------------------------------------------------------
+# Final Cleanup
+# -----------------------------------------------------------------------------
+RUN dnf clean all && \
+    rm -rf /var/cache/dnf /var/log/dnf* /var/log/hawkey*
+
+# -----------------------------------------------------------------------------
+# Labels
+# -----------------------------------------------------------------------------
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+ARG PYTHON_VERSION
+
+LABEL name="odh-midstream-rocm-base" \
+      version="${VERSION}" \
+      summary="ODH ROCm Base Image (TheRock)" \
+      description="CentOS Stream 9 with ROCm (TheRock) and Python for Open Data Hub workloads" \
+      io.k8s.display-name="ODH ROCm Base" \
+      io.k8s.description="CentOS Stream 9 with ROCm (TheRock) and Python for Open Data Hub workloads" \
+      io.openshift.tags="rocm,python,ai,ml,gpu,c9s,therock" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.title="ODH ROCm Base Image (TheRock)" \
+      org.opencontainers.image.description="CentOS Stream 9 with ROCm (TheRock) and Python for Open Data Hub workloads" \
+      org.opencontainers.image.source="https://github.com/opendatahub-io/base-containers" \
+      org.opencontainers.image.vendor="Open Data Hub" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      com.amd.rocm.version="${ROCM_VERSION}" \
+      com.opendatahub.accelerator="rocm" \
+      com.opendatahub.python="${PYTHON_VERSION}"
+
+# -----------------------------------------------------------------------------
+# User Configuration
+# -----------------------------------------------------------------------------
+USER 1001
+WORKDIR /opt/app-root/src

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For development setup and workflow, see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.m
 |--------|------------------------|------------------|
 | Python | 3.12                   | UBI 9            |
 | CUDA   | 12.8, 12.9, 13.0, 13.1, 13.2 | CentOS Stream 9  |
-| ROCm   | 6.4, 7.1               | CentOS Stream 9  |
+| ROCm   | 6.4, 7.1, 7.14         | CentOS Stream 9  |
 
 ## Pulling Base Images
 
@@ -56,6 +56,7 @@ podman pull quay.io/opendatahub/odh-midstream-cuda-base-13-2
 |---------|-------|-------------------|
 | 6.4 | `quay.io/opendatahub/odh-midstream-rocm-base-6-4` | [View on Quay.io](https://quay.io/repository/opendatahub/odh-midstream-rocm-base-6-4) |
 | 7.1 | `quay.io/opendatahub/odh-midstream-rocm-base-7-1` | [View on Quay.io](https://quay.io/repository/opendatahub/odh-midstream-rocm-base-7-1) |
+| 7.14 | `quay.io/opendatahub/odh-midstream-rocm-base-7-14` | [View on Quay.io](https://quay.io/repository/opendatahub/odh-midstream-rocm-base-7-14) |
 
 ```bash
 # Pull ROCm 6.4 base image (x86_64 only)
@@ -63,6 +64,9 @@ podman pull quay.io/opendatahub/odh-midstream-rocm-base-6-4
 
 # Pull ROCm 7.1 base image (x86_64 only)
 podman pull quay.io/opendatahub/odh-midstream-rocm-base-7-1
+
+# Pull ROCm 7.14 base image (x86_64 only)
+podman pull quay.io/opendatahub/odh-midstream-rocm-base-7-14
 ```
 
 ## Repository Structure

--- a/rocm/7.14/Containerfile
+++ b/rocm/7.14/Containerfile
@@ -1,0 +1,261 @@
+# ODH ROCm Base Image - TheRock (CentOS Stream 9)
+# ROCm Version: ${ROCM_MAJOR_MINOR_DOT}
+# Generated from Containerfile.rocm-therock.template - edit template, not this file
+#
+# For ROCm 7.14+ which uses TheRock multi-arch packages (amdrocm-*).
+# Legacy ROCm versions (6.4, 7.1) use Containerfile.rocm.template instead.
+#
+# CentOS Stream 9 required: ROCm packages need CentOS Stream 9 / RHEL 9 repos
+# Usage: ./scripts/build.sh rocm-${ROCM_MAJOR_MINOR_DOT}
+# Build args: rocm/${ROCM_MAJOR_MINOR_DOT}/app.conf
+
+ARG BASE_IMAGE
+ARG ROCM_MAJOR
+ARG ROCM_MAJOR_MINOR
+ARG ROCM_MAJOR_MINOR_DOT
+ARG ROCM_VERSION
+ARG RELEASEVER
+
+# TheRock repository URL for amdrocm-* packages
+ARG THEROCK_REPO_URL
+
+# Frameworks repository URL for migraphx packages
+ARG FRAMEWORKS_REPO_URL
+
+# ROCm install prefix (7.14+ uses /opt/rocm/core)
+ARG ROCM_HOME=/opt/rocm/core
+
+# Build metadata for OCI labels
+ARG BUILD_DATE
+ARG VCS_REF=unknown
+ARG VERSION=0.0.1
+
+# -----------------------------------------------------------------------------
+# Base stage (x86_64 only - ROCm does not support ARM64)
+# -----------------------------------------------------------------------------
+FROM ${BASE_IMAGE} AS rocm-base
+
+ARG ROCM_MAJOR
+ARG ROCM_MAJOR_MINOR
+ARG ROCM_MAJOR_MINOR_DOT
+ARG ROCM_VERSION
+ARG RELEASEVER
+ARG THEROCK_REPO_URL
+ARG FRAMEWORKS_REPO_URL
+ARG ROCM_HOME
+
+USER 0
+WORKDIR /opt/app-root/bin
+
+# -----------------------------------------------------------------------------
+# ROCm Version Environment
+# -----------------------------------------------------------------------------
+ENV ROCM_VERSION=${ROCM_VERSION}
+ENV ROCM_HOME=${ROCM_HOME}
+
+# -----------------------------------------------------------------------------
+# TheRock Repository Setup
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf install -y --setopt=keepcache=1 --allowerasing curl ca-certificates
+
+# ROCm GPG keys (GA + TheRock, matching downstream configuration)
+RUN curl -fsSL "https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/pki/rpm-gpg/RPM-GPG-KEY-AMD-ROCM && \
+    curl -fsSL "https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg" > /etc/pki/rpm-gpg/RPM-GPG-KEY-AMD-ROCM-THEROCK
+
+RUN { echo "[therock]"; \
+      echo "name=TheRock ROCm ${ROCM_VERSION}"; \
+      echo "baseurl=${THEROCK_REPO_URL}"; \
+      echo "enabled=1"; \
+      echo "priority=150"; \
+      echo "gpgcheck=1"; \
+      echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AMD-ROCM"; \
+      echo "       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AMD-ROCM-THEROCK"; \
+    } > /etc/yum.repos.d/rocm.repo
+
+# Frameworks repository for migraphx (separate from main TheRock packages)
+RUN { echo "[rocm-frameworks]"; \
+      echo "name=ROCm Frameworks (migraphx)"; \
+      echo "baseurl=${FRAMEWORKS_REPO_URL}"; \
+      echo "enabled=1"; \
+      echo "priority=200"; \
+      echo "gpgcheck=0"; \
+    } > /etc/yum.repos.d/rocm-frameworks.repo
+
+# -----------------------------------------------------------------------------
+# ROCm Packages (TheRock amdrocm-* multi-arch)
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf install -y --setopt=keepcache=1 \
+      gcc-toolset-14 \
+      gcc-toolset-14-gcc-c++ \
+      gcc-toolset-14-gcc-gfortran \
+      gcc-toolset-14-libatomic-devel \
+      libdrm \
+      amdrocm-amdsmi \
+      amdrocm-llvm \
+      amdrocm-runtime \
+      amdrocm-runtime-devel \
+      amdrocm-rccl \
+      amdrocm-rccl-devel \
+      amdrocm-math-common \
+      amdrocm-core-sdk \
+      amdrocm-core-devel \
+      amdrocm-blas \
+      amdrocm-blas-devel \
+      amdrocm-dnn \
+      amdrocm-dnn-devel \
+      amdrocm-fft \
+      amdrocm-fft-devel \
+      amdrocm-solver \
+      amdrocm-solver-devel \
+      amdrocm-sparse \
+      amdrocm-sparse-devel \
+      amdrocm-rand \
+      amdrocm-rand-devel \
+      amdrocm-ccl-devel \
+      amdrocm-migraphx \
+      amdrocm-migraphx-devel
+
+# Configure ROCm library paths
+ENV PATH=${ROCM_HOME}/bin:${ROCM_HOME}/hip/bin:${PATH}
+ENV LD_LIBRARY_PATH=${ROCM_HOME}/lib:${ROCM_HOME}/lib64
+
+# -----------------------------------------------------------------------------
+# Post-install: symlinks for backward compatibility (/opt/rocm -> /opt/rocm/core)
+# -----------------------------------------------------------------------------
+RUN ln -sfn "${ROCM_HOME}"/include /opt/rocm/include && \
+    ln -sfn "${ROCM_HOME}"/lib /opt/rocm/lib && \
+    ln -sfn "${ROCM_HOME}"/bin /opt/rocm/bin && \
+    ln -sfn "${ROCM_HOME}"/share /opt/rocm/share && \
+    for subdir in llvm hip; do \
+      if [ -d "${ROCM_HOME}/${subdir}" ]; then \
+        ln -sfn "${ROCM_HOME}/${subdir}" "/opt/rocm/${subdir}"; \
+      fi; \
+    done
+
+# Fix shebangs in ROCm CLI tools to use system Python
+RUN for script in "${ROCM_HOME}/bin/amd-smi" "${ROCM_HOME}/bin/rocm-smi"; do \
+      if [ -f "${script}" ]; then \
+        sed -i -e '1s,#!/usr/bin/env python3,#!/usr/bin/python3,' "${script}"; \
+      fi; \
+    done
+
+# Register amdsmi package on the Python import path
+RUN if [ -d "${ROCM_HOME}/share/amd_smi" ]; then \
+      echo "${ROCM_HOME}/share/amd_smi" \
+        > "$(python -c "import sysconfig; print(sysconfig.get_path('platlib'))")"/rocm-amdsmi.pth; \
+    fi
+
+# -----------------------------------------------------------------------------
+# ROCm Shared Library Configuration
+# -----------------------------------------------------------------------------
+RUN echo "${ROCM_HOME}/lib" > /etc/ld.so.conf.d/rocm.conf && \
+    echo "${ROCM_HOME}/lib64" >> /etc/ld.so.conf.d/rocm.conf && \
+    printf '%s\n' \
+      "/opt/rh/gcc-toolset-14/root/usr/lib64" \
+      "/opt/rh/gcc-toolset-14/root/usr/lib" \
+      > /etc/ld.so.conf.d/gcc-toolset-14.conf && \
+    ldconfig
+
+# gcc-toolset-14 compiler environment
+ENV PATH=/opt/rh/gcc-toolset-14/root/usr/bin:${PATH} \
+    PKG_CONFIG_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64/pkgconfig
+
+# -----------------------------------------------------------------------------
+# Development Tools
+# -----------------------------------------------------------------------------
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=odh-base-containers-rocm-dnf \
+    dnf install -y --setopt=keepcache=1 make findutils
+
+# -----------------------------------------------------------------------------
+# Environment (consistent with Python base image)
+# -----------------------------------------------------------------------------
+
+# Python settings - prevent bytecode files and enable unbuffered output
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    UV_NO_CACHE=1 \
+    UV_PYTHON_DOWNLOADS=never
+
+# -----------------------------------------------------------------------------
+# Package Index Configuration
+# -----------------------------------------------------------------------------
+ARG PIP_INDEX_URL=https://pypi.org/simple
+ARG PIP_EXTRA_INDEX_URL
+ARG UV_TORCH_BACKEND=
+
+# pip configuration (system-wide)
+RUN mkdir -p /etc/pip && \
+    { echo "[global]"; \
+      echo "index-url = ${PIP_INDEX_URL}"; \
+      [ -n "${PIP_EXTRA_INDEX_URL}" ] && echo "extra-index-url = ${PIP_EXTRA_INDEX_URL}"; \
+      true; \
+    } > /etc/pip.conf
+
+# Install uv - fast Python package installer
+# https://github.com/astral-sh/uv
+# Version pinned in requirements-build.txt
+COPY --chmod=644 --chown=0:0 requirements-build.txt /tmp/requirements-build.txt
+RUN python -m pip install --no-cache-dir --require-hashes -r /tmp/requirements-build.txt && \
+    rm /tmp/requirements-build.txt
+
+# uv configuration (system-wide)
+RUN mkdir -p /etc/uv && \
+    { echo "[pip]"; \
+      echo "index-url = \"${PIP_INDEX_URL}\""; \
+      [ -n "${UV_TORCH_BACKEND}" ] && echo "torch-backend = \"${UV_TORCH_BACKEND}\""; \
+      true; \
+    } > /etc/uv/uv.toml
+ENV UV_CONFIG_FILE=/etc/uv/uv.toml
+
+# Copy fix-permissions script from sclorg for OpenShift compatibility
+COPY --chmod=755 --chown=0:0 scripts/fix-permissions /usr/local/bin/fix-permissions
+
+# -----------------------------------------------------------------------------
+# Directory Setup
+# -----------------------------------------------------------------------------
+RUN mkdir -p /opt/app-root/src/.cache && \
+    chown -R 1001:0 /opt/app-root && \
+    fix-permissions /opt/app-root -P
+
+# -----------------------------------------------------------------------------
+# Final Cleanup
+# -----------------------------------------------------------------------------
+RUN dnf clean all && \
+    rm -rf /var/cache/dnf /var/log/dnf* /var/log/hawkey*
+
+# -----------------------------------------------------------------------------
+# Labels
+# -----------------------------------------------------------------------------
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+ARG PYTHON_VERSION
+
+LABEL name="odh-midstream-rocm-base" \
+      version="${VERSION}" \
+      summary="ODH ROCm Base Image (TheRock)" \
+      description="CentOS Stream 9 with ROCm (TheRock) and Python for Open Data Hub workloads" \
+      io.k8s.display-name="ODH ROCm Base" \
+      io.k8s.description="CentOS Stream 9 with ROCm (TheRock) and Python for Open Data Hub workloads" \
+      io.openshift.tags="rocm,python,ai,ml,gpu,c9s,therock" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.title="ODH ROCm Base Image (TheRock)" \
+      org.opencontainers.image.description="CentOS Stream 9 with ROCm (TheRock) and Python for Open Data Hub workloads" \
+      org.opencontainers.image.source="https://github.com/opendatahub-io/base-containers" \
+      org.opencontainers.image.vendor="Open Data Hub" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      com.amd.rocm.version="${ROCM_VERSION}" \
+      com.opendatahub.accelerator="rocm" \
+      com.opendatahub.python="${PYTHON_VERSION}"
+
+# -----------------------------------------------------------------------------
+# User Configuration
+# -----------------------------------------------------------------------------
+USER 1001
+WORKDIR /opt/app-root/src

--- a/rocm/7.14/app.conf
+++ b/rocm/7.14/app.conf
@@ -1,0 +1,77 @@
+# =============================================================================
+# ODH Base Containers - ROCm 7.14 Build Arguments
+# =============================================================================
+#
+# Build arguments for ROCm 7.14 base image (AMD GPU workloads).
+# This file is passed directly to podman/buildah via --build-arg-file.
+#
+# ROCm 7.14 uses TheRock multi-arch packages (amdrocm-*) instead of the
+# traditional rocm-core/rocblas/etc. naming used in ROCm <= 7.2.
+#
+# Source: https://rocm.prereleases.amd.com/packages-multi-arch/rhel9/x86_64/
+#
+# Usage:
+#   ./scripts/build.sh rocm-7.14
+#
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Image Tag (used by build.sh)
+# -----------------------------------------------------------------------------
+IMAGE_TAG=7.14-py312
+
+# Python version bundled with this ROCm image (used in container labels)
+PYTHON_VERSION=3.12
+
+# -----------------------------------------------------------------------------
+# Base Image
+# -----------------------------------------------------------------------------
+# Use sclorg Python image on CentOS Stream 9 (same base as CUDA images)
+# Digest is pinned for reproducible builds and auto-updated by Renovate
+# Source: https://quay.io/repository/sclorg/python-312-c9s
+BASE_IMAGE=quay.io/sclorg/python-312-c9s:c9s@sha256:5f72aa1e1955fb440740db81db2120127044f4196fbc15d672b4e688758baac8
+
+# -----------------------------------------------------------------------------
+# ROCm Versions
+# Source: https://rocm.prereleases.amd.com/packages-multi-arch/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+ROCM_MAJOR=7
+ROCM_MAJOR_MINOR=7-14
+ROCM_MAJOR_MINOR_DOT=7.14
+ROCM_VERSION=7.14.0
+
+# RHEL minor version for repo URLs.
+# CentOS Stream 9 reports VERSION_ID=9 which has no matching AMD repo path,
+# so we pin the specific minor version here.
+RELEASEVER=9.6
+
+# -----------------------------------------------------------------------------
+# TheRock Repository
+# ROCm 7.14 uses amdrocm-* multi-arch packages from AMD's TheRock build system.
+# Source: https://repo.amd.com/rocm/packages-multi-arch/rhel9/x86_64/
+# -----------------------------------------------------------------------------
+THEROCK_REPO_URL=https://repo.amd.com/rocm/packages-multi-arch/rhel9/x86_64/
+
+# -----------------------------------------------------------------------------
+# Frameworks Repository (migraphx)
+# MIGraphX is distributed separately from the main TheRock packages.
+# Source: https://rocm.frameworks.amd.com/rpm-multi-arch/amdrocm-migraphx/
+# -----------------------------------------------------------------------------
+FRAMEWORKS_REPO_URL=https://rocm.frameworks.amd.com/rpm-multi-arch/amdrocm-migraphx/
+
+# ROCm 7.14 installs under /opt/rocm/core instead of /opt/rocm.
+# The Containerfile creates symlinks for backward compatibility.
+ROCM_HOME=/opt/rocm/core
+
+# -----------------------------------------------------------------------------
+# PyPI Indexes
+# Source: https://rocm.prereleases.amd.com/whl-staging-multi-arch/
+# -----------------------------------------------------------------------------
+PIP_INDEX_URL=https://pypi.org/simple
+PIP_EXTRA_INDEX_URL=https://rocm.prereleases.amd.com/whl-staging-multi-arch/
+
+# -----------------------------------------------------------------------------
+# uv PyTorch Backend
+# https://docs.astral.sh/uv/guides/integration/pytorch/
+# -----------------------------------------------------------------------------
+UV_TORCH_BACKEND=

--- a/tests/test_rocm_image.py
+++ b/tests/test_rocm_image.py
@@ -36,13 +36,19 @@ def test_rocm_home(rocm_container):
     """Verify ROCM_HOME points to the ROCm installation directory.
 
     PyTorch and other ML frameworks use ROCM_HOME to locate the ROCm toolkit.
+    ROCm <= 7.2 uses /opt/rocm; ROCm 7.14+ (TheRock) uses /opt/rocm/core.
     """
-    assert rocm_container.get_env("ROCM_HOME") == "/opt/rocm"
+    rocm_home = rocm_container.get_env("ROCM_HOME")
+    assert rocm_home in ("/opt/rocm", "/opt/rocm/core"), (
+        f"Expected ROCM_HOME to be /opt/rocm or /opt/rocm/core, got {rocm_home}"
+    )
 
 
 def test_rocm_in_path(rocm_container):
     """Verify ROCm bin directory is in PATH."""
-    assert "/opt/rocm/bin" in rocm_container.get_env("PATH")
+    path = rocm_container.get_env("PATH")
+    rocm_home = rocm_container.get_env("ROCM_HOME") or "/opt/rocm"
+    assert f"{rocm_home}/bin" in path, f"Expected {rocm_home}/bin in PATH, got {path}"
 
 
 # --- ROCm Directory Tests ---
@@ -131,19 +137,20 @@ def test_uv_torch_backend(rocm_container):
     Uses a specific backend (e.g. rocm6.4) rather than "auto" because
     auto detects GPU drivers at runtime, which are absent during container builds.
     Configured via uv.toml (not ENV) to avoid uv erroring on empty values.
+
+    ROCm 7.14+: uv does not yet support rocm7.14 as a torch-backend value,
+    so torch-backend may be absent. Test is skipped in that case.
     """
     result = rocm_container.run("cat /etc/uv/uv.toml")
     assert result.returncode == 0, "Failed to read /etc/uv/uv.toml"
-    assert "torch-backend" in result.stdout, (
-        "torch-backend should be configured in /etc/uv/uv.toml for ROCm images"
-    )
-    # Verify it's set to a valid ROCm backend (rocmX.Y format), not "auto" or "cpu"
+
+    if "torch-backend" not in result.stdout:
+        pytest.skip(
+            "torch-backend not configured (expected for ROCm versions not yet supported by uv)"
+        )
+
     match = re.search(r'torch-backend\s*=\s*"(rocm\d+\.\d+)"', result.stdout)
     assert match, f'Expected torch-backend = "rocmX.Y" in uv.toml, got:\n{result.stdout}'
-    # If UV_TORCH_BACKEND is set in the test environment, verify the exact value matches.
-    # Note: UV_TORCH_BACKEND is intentionally not passed in CI. The downstream build
-    # overwrites /etc/uv/uv.toml with its own config, so the exact value set here
-    # has no downstream impact. The loose format check above is sufficient.
     expected_backend = os.environ.get("UV_TORCH_BACKEND")
     if expected_backend is not None:
         assert match.group(1) == expected_backend, (


### PR DESCRIPTION
ROCm 7.14 uses AMD's new TheRock packaging model which is a significant change from 6.4/7.1. Added separate Containerfile.rocm-therock.template to keep legacy versions untouched.
    
Differences from legacy ROCm:
    - Packages are amdrocm-* multi-arch (installed for all GPU architectures)
    - Installs to /opt/rocm/core instead of /opt/rocm (symlinks for compat)
    - Requires gcc-toolset-14
    - UV_TORCH_BACKEND not yet supported by uv for rocm7.14
    
Also bumps pipeline timeout to 4h and task-level memory to 24Gi as image is ~3.3GB so post-build steps need more resources

Closes #237

## Checklist
<!-- Check items that apply. Strike through items that don't apply to this PR: ~[ ]~ -->

### All PRs
- [ ] Linting, formatting, and type checks pass (`tox -e lint`, `tox -e type`)
- [ ] Tests added/updated where applicable (`tox -e test`)

### Containerfile / image changes
- [ ] Edited the `Containerfile.*.template`, not version-specific `<type>/<version>/Containerfile` directly
- [ ] Regenerated version-specific Containerfiles (`./scripts/generate-containerfile.sh`)
- [ ] Containerfile linting passes (`./scripts/lint-containerfile.sh`)
- [ ] Versions and URLs are in `app.conf` build args, not hardcoded
- [ ] Image builds successfully (`./scripts/build.sh <type>-<version>`)
- [ ] No `:latest` tags or root (UID 0) user in container images


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ROCm 7.14 base image support, including new container build config and image tagging for automated pull-request and push workflows.
  * Updated CI pipeline-run configurations to run with tuned security-scanning and preflight checks.
* **Documentation**
  * Updated README and contributor documentation to include ROCm 7.14, new repository layout, and build/pull examples.
* **Tests**
  * Updated ROCm image tests to accept either `/opt/rocm` or `/opt/rocm/core` and to validate the optional uv `torch-backend` setting when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->